### PR TITLE
feat: JS injection + bidirectional messaging

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,10 @@ let package = Package(
         // standalone and is re-exposed on the hybrid class via
         // `parseContentDispositionFilename(_:)`.
         "NitroWebViewContentDispositionParser.swift",
+        // Native→web message-delivery statement builder + JS-source-string
+        // escaping. Standalone for the same reason — re-exposed on the
+        // hybrid via `HybridNitroWebView.postMessageScript(_:)`.
+        "NitroWebViewPostMessage.swift",
       ]
     ),
     .testTarget(
@@ -194,6 +198,17 @@ let package = Package(
       name: "HybridNitroWebViewCachePolicyTests",
       dependencies: ["NitroWebViewSource"],
       path: "iosTests/Tests/HybridNitroWebViewCachePolicyTests"
+    ),
+    .testTarget(
+      // Exercises the native→web `postMessage` statement builder +
+      // JS-source-string escaping in `NitroWebViewPostMessage` (which backs
+      // `HybridNitroWebView.postMessageScript(_:)`). Asserts the emitted
+      // statement is valid JS, escapes U+2028/U+2029, and carries the
+      // payload verbatim — the Swift mirror of the TS oracle in
+      // `src/__tests__/post-message-escaping.test.ts`.
+      name: "HybridNitroWebViewPostMessageTests",
+      dependencies: ["NitroWebViewSource"],
+      path: "iosTests/Tests/HybridNitroWebViewPostMessageTests"
     ),
   ]
 )

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ The exported React component. Backed by `getHostComponent<NitroWebViewProps, Nit
 | `allowsBackForwardNavigationGestures` | `boolean` | iOS-only: back/forward swipe gestures (mutable). Android: no-op. |
 | `thirdPartyCookiesEnabled` | `boolean` | Android-only: `setAcceptThirdPartyCookies` for this WebView (mutable). iOS: no-op. |
 | `sharedCookiesEnabled` | `boolean` | iOS-only: **no-op** - Nitro delivers props after `WKWebView` init, so sharing `HTTPCookieStorage` is never applied. Android: no-op (one process-wide store). |
-| `injectedJavaScript` | `string` | Fire-and-forget script run on every page load. |
+| `injectedJavaScript` | `string` | Fire-and-forget script run at document-END on every page load. |
+| `injectedJavaScriptBeforeContentLoaded` | `string` | Script run at document-START, before the page's own scripts. iOS: `WKUserScript(.atDocumentStart)` (hard before-any-script guarantee). Android: `WebViewCompat.addDocumentStartJavaScript` when the WebView supports `DOCUMENT_START_SCRIPT`, else `evaluateJavascript` in `onPageStarted` (early, but not a strict before-first-script guarantee). Main frame only. |
 | `onLoadStart` | `(event: WebViewLoadEvent) => void` | Fired when the WebView begins loading content. |
 | `onLoadEnd` | `(event: WebViewLoadEvent) => void` | Fired when the WebView finishes loading content. |
 | `onNavigationStateChange` | `(state: WebViewNavigationState) => void` | URL / title / `canGoBack` / `canGoForward` / `loading`. |
@@ -140,6 +141,8 @@ The hybrid ref captured by `hybridRef={callback((r) => ref.current = r)}` expose
 | `reload()` | `void` | Reload the current page. |
 | `stopLoading()` | `void` | Stop the current load. |
 | `evaluateJavaScript(code)` | `Promise<string>` | Result is the serialized string evaluation. iOS uses `String(describing:)`; Android uses the JSON-encoded `ValueCallback<String>` result. Undefined/nil surfaces as `''`. |
+| `injectJavaScript(code)` | `void` | Fire-and-forget execution — no result awaited. Use for side effects only. No-op if no page is loaded. |
+| `postMessage(data)` | `void` | Push a string into the page as a DOM `message` event (`event.data === data`). Listen on **both** targets for portability: `window.addEventListener('message', ...)` (iOS) and `document.addEventListener('message', ...)` (Android). Dispatched once, no buffering. `data` is escaped safely (quotes, newlines, `</script>`, unicode). |
 | `getCookies(url)` | `Promise<Cookie[]>` | iOS returns the full attribute set. Android `CookieManager` only exposes `name` and `value` on read — other fields are left `undefined`. |
 | `setCookie(url, cookie)` | `Promise<void>` | `Cookie = { name, value, domain?, path?, expires?, secure?, httpOnly? }`. `expires` is milliseconds since epoch (`Date.now()`-compatible). |
 | `clearCookies()` | `Promise<void>` | Bulk clear via `WKWebsiteDataStore` (iOS) / `CookieManager.removeAllCookies` (Android). The promise resolves only after the platform reports completion. |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -153,6 +153,13 @@ dependencies {
   // File-upload pathway: AndroidX FileProvider for camera capture URIs.
   implementation "androidx.core:core-ktx:1.13.1"
 
+  // Document-start JS injection: WebViewCompat.addDocumentStartJavaScript
+  // (gated on the DOCUMENT_START_SCRIPT feature) gives the same
+  // before-any-page-script guarantee as iOS `.atDocumentStart`, with an
+  // onPageStarted fallback on older WebViews. react-native-webview depends
+  // on the same artifact.
+  implementation "androidx.webkit:webkit:1.14.0"
+
   // File-download pathway: Mozilla Android Components' DownloadUtils
   // provides `guessFileName(url, contentDisposition, mimeType)`.
   implementation "org.mozilla.components:support-utils:127.0.2"

--- a/android/src/main/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebView.kt
+++ b/android/src/main/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebView.kt
@@ -795,11 +795,7 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
     /**
      * Build the native→web `postMessage` delivery statement. Android
      * dispatches a DOM `message` event on `document`
-     * (`RNCWebViewManagerImpl.kt:335`). Mirror of the TS
-     * `buildPostMessageScript('android', _)` — the pure-TS test in
-     * `src/__tests__/post-message-escaping.test.ts` is the canonical oracle;
-     * this @JvmStatic helper (no WebView dependency) lets JVM unit tests
-     * assert the same emitted shape without Robolectric.
+     * (`RNCWebViewManagerImpl.kt:335`).
      */
     @JvmStatic
     internal fun postMessageScript(message: String): String {

--- a/android/src/main/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebView.kt
+++ b/android/src/main/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebView.kt
@@ -13,6 +13,8 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 import com.facebook.react.bridge.ActivityEventListener
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.ThemedReactContext
@@ -32,6 +34,7 @@ import com.margelo.nitro.nitrowebview.WebViewNavigationState
 import com.margelo.nitro.nitrowebview.WebViewNavigationType
 import com.margelo.nitro.nitrowebview.WebViewSource
 import mozilla.components.support.utils.DownloadUtils
+import org.json.JSONObject
 import java.net.URLDecoder
 
 @SuppressLint("SetJavaScriptEnabled")
@@ -250,6 +253,31 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
       // Re-injects on every page load via onPageFinished hook below.
     }
 
+  /**
+   * JS injected before the page's own scripts run, on every main-frame
+   * load. When the device's WebView supports the `DOCUMENT_START_SCRIPT`
+   * feature we register it via `WebViewCompat.addDocumentStartJavaScript`
+   * (the same before-any-page-script guarantee as iOS `.atDocumentStart`);
+   * otherwise it is injected in [ClientImpl.onPageStarted], which is early
+   * enough for shim installation but does not strictly beat a page's first
+   * synchronous inline `<script>`.
+   */
+  override var injectedJavaScriptBeforeContentLoaded: String? = null
+    set(value) {
+      field = value
+      view.post { applyDocumentStartScript() }
+    }
+
+  /**
+   * Handle returned by `WebViewCompat.addDocumentStartJavaScript` for the
+   * currently-registered before-content script. Held so a prop change can
+   * remove the previous registration before adding the new one (otherwise
+   * the scripts would stack across updates). Null on WebViews that lack the
+   * `DOCUMENT_START_SCRIPT` feature — those use the `onPageStarted`
+   * fallback instead.
+   */
+  private var documentStartScriptHandler: androidx.webkit.ScriptHandler? = null
+
   override var onLoadStart: ((event: WebViewLoadEvent) -> Unit)? = null
   override var onLoadEnd: ((event: WebViewLoadEvent) -> Unit)? = null
   override var onNavigationStateChange: ((state: WebViewNavigationState) -> Unit)? = null
@@ -317,6 +345,50 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
       )
     }
     return promise
+  }
+
+  /**
+   * Fire-and-forget JS execution — no result surfaced to JS. Hops to the UI
+   * thread like every other WebView-touching method (`evaluateJavascript`
+   * is main-thread-only and the Nitro call can land off-thread).
+   */
+  override fun injectJavaScript(code: String) {
+    view.post { view.evaluateJavascript(code, null) }
+  }
+
+  /**
+   * Deliver a native→web message. Android dispatches a DOM `message` event
+   * on `document` (react-native-webview parity —
+   * `RNCWebViewManagerImpl.kt:335`). The statement is built + escaped by the
+   * companion [postMessageScript] helper, then evaluated fire-and-forget.
+   */
+  override fun postMessage(data: String) {
+    view.post { view.evaluateJavascript(postMessageScript(data), null) }
+  }
+
+  /**
+   * Register (or re-register) the before-content script via
+   * `WebViewCompat.addDocumentStartJavaScript` when the feature is
+   * supported. Removes any previous registration first so prop changes
+   * don't stack scripts. No-op when the feature is unsupported — those
+   * WebViews fall back to injecting in [ClientImpl.onPageStarted].
+   *
+   * Must run on the UI thread (callers hop via `view.post`).
+   */
+  private fun applyDocumentStartScript() {
+    if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+      return
+    }
+    documentStartScriptHandler?.remove()
+    documentStartScriptHandler = null
+    val script = injectedJavaScriptBeforeContentLoaded
+    if (script.isNullOrEmpty()) return
+    // Wrap in an IIFE for scope isolation, matching react-native-webview.
+    documentStartScriptHandler = WebViewCompat.addDocumentStartJavaScript(
+      view,
+      "(function(){\n$script\n})();",
+      setOf("*"),
+    )
   }
 
   // region: Cookie API
@@ -487,6 +559,17 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
 
   private inner class ClientImpl : WebViewClient() {
     override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+      // Fallback path for WebViews without the DOCUMENT_START_SCRIPT
+      // feature: inject the before-content script here. Supported WebViews
+      // register it via addDocumentStartJavaScript (see
+      // applyDocumentStartScript) and skip this to avoid a double-inject.
+      val before = injectedJavaScriptBeforeContentLoaded
+      if (
+        !before.isNullOrEmpty() &&
+        !WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)
+      ) {
+        view.evaluateJavascript("(function(){\n$before\n})();", null)
+      }
       emitLoadStart()
       emitNavigationState()
     }
@@ -708,6 +791,36 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
 
   companion object {
     private const val BRIDGE_NAME = "ReactNativeWebView"
+
+    /**
+     * Build the native→web `postMessage` delivery statement. Android
+     * dispatches a DOM `message` event on `document`
+     * (`RNCWebViewManagerImpl.kt:335`). Mirror of the TS
+     * `buildPostMessageScript('android', _)` — the pure-TS test in
+     * `src/__tests__/post-message-escaping.test.ts` is the canonical oracle;
+     * this @JvmStatic helper (no WebView dependency) lets JVM unit tests
+     * assert the same emitted shape without Robolectric.
+     */
+    @JvmStatic
+    internal fun postMessageScript(message: String): String {
+      val data = encodeJsStringLiteral(message)
+      return "document.dispatchEvent(new MessageEvent('message',{data:$data}));"
+    }
+
+    /**
+     * Escape a string into a JS *source* string literal (double-quoted,
+     * quotes included). `JSONObject.quote` (bundled in android.jar) handles
+     * quotes, backslashes, newlines, and control chars exactly like
+     * `JSON.stringify` — and, like it, leaves U+2028/U+2029 RAW, which are
+     * illegal *unescaped* inside a JS string literal on pre-ES2019 engines.
+     * Post-escape those two so the emitted statement always parses.
+     */
+    @JvmStatic
+    internal fun encodeJsStringLiteral(message: String): String {
+      return JSONObject.quote(message)
+        .replace(" ", "\\u2028")
+        .replace(" ", "\\u2029")
+    }
 
     /**
      * Maximum number of milliseconds [ClientImpl.shouldOverrideUrlLoading]

--- a/android/src/test/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebViewPostMessageTest.kt
+++ b/android/src/test/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebViewPostMessageTest.kt
@@ -1,0 +1,89 @@
+package io.github.l2hyunwoo.nitro.webview
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * JVM/Robolectric tests for the native→web `postMessage` statement builder
+ * on [HybridNitroWebView.Companion] — the Kotlin mirror of the TS oracle in
+ * `src/__tests__/post-message-escaping.test.ts`.
+ *
+ * Runs under Robolectric so `org.json.JSONObject.quote` resolves to the real
+ * implementation (the plain-JVM android.jar stub returns default values under
+ * `returnDefaultValues = true`, which would make `quote` a no-op).
+ *
+ * For each hostile payload the emitted statement must:
+ *   1. dispatch a `message` event on `document`,
+ *   2. contain no RAW U+2028 / U+2029, and
+ *   3. round-trip the payload verbatim through JSON decoding.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class HybridNitroWebViewPostMessageTest {
+
+  private val ls = " "
+  private val ps = " "
+
+  private val hostile = listOf(
+    "",
+    "plain",
+    "has \"double\" and 'single' quotes",
+    "line1\nline2\ttab\r",
+    "</script><script>alert(1)</script>",
+    "漢字 🎉 unicode",
+    "sep${ls}here${ps}too",
+    "{\"nested\":\"json\",\"n\":42}",
+    "back\\slash",
+  )
+
+  @Test
+  fun `postMessageScript dispatches message event on document for every payload`() {
+    for (payload in hostile) {
+      val stmt = HybridNitroWebView.postMessageScript(payload)
+      assertTrue(
+        "statement must dispatch a `message` event on document: $stmt",
+        stmt.startsWith("document.dispatchEvent(new MessageEvent('message',{data:"),
+      )
+      assertTrue("statement must be closed: $stmt", stmt.endsWith("}));"))
+    }
+  }
+
+  @Test
+  fun `postMessageScript never emits raw line or paragraph separators`() {
+    for (payload in hostile) {
+      val stmt = HybridNitroWebView.postMessageScript(payload)
+      assertFalse(
+        "raw U+2028/U+2029 must not survive into the statement for ${payload.length} chars",
+        stmt.contains(ls) || stmt.contains(ps),
+      )
+    }
+  }
+
+  @Test
+  fun `encodeJsStringLiteral round-trips every payload verbatim through JSON`() {
+    for (payload in hostile) {
+      val literal = HybridNitroWebView.encodeJsStringLiteral(payload)
+      // The post-escape of U+2028/U+2029 yields JSON-legal   /
+      // escapes, so the literal is valid JSON and decodes to the payload.
+      val decoded = org.json.JSONArray("[$literal]").getString(0)
+      assertEquals(
+        "emitted literal must decode back to the payload verbatim",
+        payload,
+        decoded,
+      )
+    }
+  }
+
+  @Test
+  fun `encodeJsStringLiteral is quoted and escapes separators`() {
+    val enc = HybridNitroWebView.encodeJsStringLiteral("a${ls}b${ps}c")
+    assertTrue("must be a quoted JS literal: $enc", enc.startsWith("\"") && enc.endsWith("\""))
+    assertTrue("LS/PS must be escaped: $enc", enc.contains("\\u2028") && enc.contains("\\u2029"))
+    assertFalse("no raw LS/PS: $enc", enc.contains(ls) || enc.contains(ps))
+  }
+}

--- a/ios/HybridNitroWebView.swift
+++ b/ios/HybridNitroWebView.swift
@@ -152,7 +152,14 @@ final class HybridNitroWebView:
   var javaScriptEnabled: Bool?
 
   var injectedJavaScript: String? {
-    didSet { applyInjectedJavaScript(injectedJavaScript) }
+    didSet { reinstallUserScripts() }
+  }
+
+  /// JS injected at `.atDocumentStart` (main frame only), before any page
+  /// script runs. Distinct from `injectedJavaScript`, which runs at
+  /// `.atDocumentEnd`. Re-registers all user scripts in order on change.
+  var injectedJavaScriptBeforeContentLoaded: String? {
+    didSet { reinstallUserScripts() }
   }
 
   func goBack() throws { view.goBack() }
@@ -169,6 +176,28 @@ final class HybridNitroWebView:
       reject: { error in promise.reject(withError: error) }
     )
     return promise
+  }
+
+  /// Fire-and-forget JS execution — no result, no completion. Mirrors
+  /// react-native-webview's `injectJavaScript` (`nil` completion handler).
+  func injectJavaScript(code: String) throws {
+    view.evaluateJavaScript(code, completionHandler: nil)
+  }
+
+  /// Deliver a native→web message. iOS dispatches a DOM `message` event on
+  /// `window` (RNCWebViewImpl.m:1113). The statement is built + escaped by
+  /// the shared `NitroWebViewPostMessage` builder, then evaluated
+  /// fire-and-forget.
+  func postMessage(data: String) throws {
+    view.evaluateJavaScript(Self.postMessageScript(data), completionHandler: nil)
+  }
+
+  /// Swift-side re-export of the shared `buildPostMessageScript('ios', _)`
+  /// builder. Kept as a static (delegating to the standalone
+  /// `NitroWebViewPostMessage`) so `swift test` can assert the emitted
+  /// statement without a `WKWebView`.
+  static func postMessageScript(_ message: String) -> String {
+    NitroWebViewPostMessage.buildStatement(message)
   }
 
   // MARK: - Cookie API
@@ -303,24 +332,51 @@ final class HybridNitroWebView:
     return Dictionary(pairs, uniquingKeysWith: { _, new in new })
   }
 
-  private func applyInjectedJavaScript(_ script: String?) {
+  /// Rebuild the `WKUserContentController`'s user-script list in a fixed
+  /// order whenever `injectedJavaScript` or
+  /// `injectedJavaScriptBeforeContentLoaded` changes.
+  ///
+  /// `WKUserScript`s run in registration order within the same injection
+  /// time, so the ordering here is the contract:
+  ///   1. bridge bootstrap  — `.atDocumentStart`, all frames.
+  ///   2. before-content    — `.atDocumentStart`, main frame only. Runs
+  ///      after the bridge (so pages can still call `postMessage`) but
+  ///      before any page script.
+  ///   3. injected (after)  — `.atDocumentEnd`, main frame only.
+  ///
+  /// `removeAllUserScripts()` + re-add on every change keeps the list
+  /// idempotent regardless of the order the two props are set at mount.
+  private func reinstallUserScripts() {
     let controller = view.configuration.userContentController
     controller.removeAllUserScripts()
-    // Re-install the bridge bootstrap that lives on every page.
+
+    // 1. bridge bootstrap — always present.
     controller.addUserScript(WKUserScript(
       source: Self.bridgeBootstrapScript,
       injectionTime: .atDocumentStart,
       forMainFrameOnly: false
     ))
+
+    // 2. before-content — atDocumentStart, main frame only.
+    if let before = injectedJavaScriptBeforeContentLoaded, !before.isEmpty {
+      controller.addUserScript(WKUserScript(
+        source: before,
+        injectionTime: .atDocumentStart,
+        forMainFrameOnly: true
+      ))
+    }
+
+    // 3. after-load — atDocumentEnd, main frame only.
     currentInjectedUserScript = nil
-    guard let script, !script.isEmpty else { return }
-    let userScript = WKUserScript(
-      source: script,
-      injectionTime: .atDocumentEnd,
-      forMainFrameOnly: true
-    )
-    controller.addUserScript(userScript)
-    currentInjectedUserScript = userScript
+    if let after = injectedJavaScript, !after.isEmpty {
+      let userScript = WKUserScript(
+        source: after,
+        injectionTime: .atDocumentEnd,
+        forMainFrameOnly: true
+      )
+      controller.addUserScript(userScript)
+      currentInjectedUserScript = userScript
+    }
   }
 
   func dispatchMessage(_ event: NitroWebViewMessageEvent) {

--- a/ios/HybridNitroWebView.swift
+++ b/ios/HybridNitroWebView.swift
@@ -189,15 +189,7 @@ final class HybridNitroWebView:
   /// the shared `NitroWebViewPostMessage` builder, then evaluated
   /// fire-and-forget.
   func postMessage(data: String) throws {
-    view.evaluateJavaScript(Self.postMessageScript(data), completionHandler: nil)
-  }
-
-  /// Swift-side re-export of the shared `buildPostMessageScript('ios', _)`
-  /// builder. Kept as a static (delegating to the standalone
-  /// `NitroWebViewPostMessage`) so `swift test` can assert the emitted
-  /// statement without a `WKWebView`.
-  static func postMessageScript(_ message: String) -> String {
-    NitroWebViewPostMessage.buildStatement(message)
+    view.evaluateJavaScript(NitroWebViewPostMessage.buildStatement(data), completionHandler: nil)
   }
 
   // MARK: - Cookie API

--- a/ios/NitroWebViewPostMessage.swift
+++ b/ios/NitroWebViewPostMessage.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Native→web message-delivery statement builder — the Swift mirror of
+/// `src/bridgeScript.ts`'s `encodeJsStringLiteral` / `buildPostMessageScript`.
+///
+/// Lives standalone (not on `HybridNitroWebView`) so `swift test` can exercise
+/// the escaping on the macOS host without linking the Nitro/WKWebView-bound
+/// hybrid class — the same seam pattern used by
+/// `NitroWebViewContentDispositionParser`. The hybrid re-exposes these via
+/// `HybridNitroWebView.postMessageScript(_:)` and delivers the emitted
+/// statement through `WKWebView.evaluateJavaScript(_, completionHandler: nil)`.
+enum NitroWebViewPostMessage {
+  /// Escape a string into a JavaScript *source* string literal (double-quoted,
+  /// quotes included). Mirrors the TS `encodeJsStringLiteral`:
+  ///
+  ///   - `JSONSerialization` produces a valid JSON string for quotes,
+  ///     backslashes, newlines, and control chars — the same escapes
+  ///     `JSON.stringify` emits. It needs a container, so we serialize a
+  ///     single-element array and strip the surrounding `[` / `]`.
+  ///   - Like `JSON.stringify`, it leaves U+2028 / U+2029 RAW, which are
+  ///     illegal *unescaped* inside a JS string literal on pre-ES2019 engines.
+  ///     We post-escape them so the emitted statement always parses.
+  static func encodeJsStringLiteral(_ value: String) -> String {
+    let literal: String
+    if let data = try? JSONSerialization.data(
+      withJSONObject: [value],
+      options: []
+    ),
+      let array = String(data: data, encoding: .utf8) {
+      // `["<escaped>"]` → drop the outer brackets to get `"<escaped>"`.
+      literal = String(array.dropFirst().dropLast())
+    } else {
+      // Defensive: JSONSerialization never fails for a [String], but fall
+      // back to a bare quoted form rather than emitting invalid JS.
+      literal = "\"\(value)\""
+    }
+    return
+      literal
+      .replacingOccurrences(of: "\u{2028}", with: "\\u2028")
+      .replacingOccurrences(of: "\u{2029}", with: "\\u2029")
+  }
+
+  /// Build the one-shot delivery statement. iOS dispatches on `window`
+  /// (react-native-webview parity — `RNCWebViewImpl.m:1113`).
+  static func buildStatement(_ message: String) -> String {
+    let data = encodeJsStringLiteral(message)
+    return "window.dispatchEvent(new MessageEvent('message',{data:\(data)}));"
+  }
+}

--- a/iosTests/Tests/HybridNitroWebViewPostMessageTests/HybridNitroWebViewPostMessageTests.swift
+++ b/iosTests/Tests/HybridNitroWebViewPostMessageTests/HybridNitroWebViewPostMessageTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import XCTest
+
+@testable import NitroWebViewSource
+
+/// Swift mirror of the TS escaping oracle
+/// (`src/__tests__/post-message-escaping.test.ts`). Exercises the
+/// `NitroWebViewPostMessage` builder that backs
+/// `HybridNitroWebView.postMessageScript(_:)`.
+///
+/// For each hostile payload the emitted statement must:
+///   1. contain no RAW U+2028 / U+2029 (illegal unescaped in a pre-ES2019
+///      JS source string),
+///   2. wrap the payload as a `window.dispatchEvent(new MessageEvent(...))`
+///      call, and
+///   3. round-trip the payload verbatim — decoding the emitted JS string
+///      literal back through `JSONSerialization` yields the original bytes
+///      (the same guarantee the TS `vm` sandbox asserts via `event.data`).
+final class HybridNitroWebViewPostMessageTests: XCTestCase {
+
+  private let ls = "\u{2028}"
+  private let ps = "\u{2029}"
+
+  private lazy var hostile: [String] = [
+    "",
+    "plain",
+    "has \"double\" and 'single' quotes",
+    "line1\nline2\ttab\r",
+    "</script><script>alert(1)</script>",
+    "漢字 🎉 unicode",
+    "sep\(ls)here\(ps)too",
+    "{\"nested\":\"json\",\"n\":42}",
+    "back\\slash",
+  ]
+
+  func test_emittedStatement_hasNoRawLineOrParagraphSeparators() {
+    for payload in hostile {
+      let stmt = NitroWebViewPostMessage.buildStatement(payload)
+      XCTAssertFalse(
+        stmt.contains(ls) || stmt.contains(ps),
+        "raw U+2028/U+2029 must not survive into the statement: \(payload.debugDescription)"
+      )
+    }
+  }
+
+  func test_emittedStatement_dispatchesMessageEventOnWindow() {
+    for payload in hostile {
+      let stmt = NitroWebViewPostMessage.buildStatement(payload)
+      XCTAssertTrue(
+        stmt.hasPrefix(
+          "window.dispatchEvent(new MessageEvent('message',{data:"
+        ),
+        "statement must dispatch a `message` event on window: \(stmt)"
+      )
+      XCTAssertTrue(stmt.hasSuffix("}));"), "statement must be closed: \(stmt)")
+    }
+  }
+
+  func test_emittedLiteral_roundTripsPayloadVerbatim() throws {
+    for payload in hostile {
+      let literal = NitroWebViewPostMessage.encodeJsStringLiteral(payload)
+      // Decode the JS string literal back through JSON. The post-escape of
+      // U+2028/U+2029 produces the JSON-legal ` `/` ` escapes, so
+      // the literal is valid JSON and must decode to the original payload.
+      let data = Data("[\(literal)]".utf8)
+      let decoded = try JSONSerialization.jsonObject(with: data) as? [String]
+      XCTAssertEqual(
+        decoded?.first,
+        payload,
+        "emitted literal must decode back to the payload verbatim: \(payload.debugDescription)"
+      )
+    }
+  }
+
+  func test_encodeJsStringLiteral_isQuotedAndEscapesSeparators() {
+    let enc = NitroWebViewPostMessage.encodeJsStringLiteral("a\(ls)b\(ps)c")
+    XCTAssertTrue(
+      enc.hasPrefix("\"") && enc.hasSuffix("\""),
+      "must be a quoted JS literal: \(enc)"
+    )
+    XCTAssertTrue(
+      enc.contains("\\u2028") && enc.contains("\\u2029"),
+      "LS/PS must be escaped: \(enc)"
+    )
+    XCTAssertFalse(enc.contains(ls) || enc.contains(ps), "no raw LS/PS: \(enc)")
+  }
+}

--- a/nitrogen/generated/android/c++/JHybridNitroWebViewSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridNitroWebViewSpec.cpp
@@ -265,6 +265,15 @@ namespace margelo::nitro::nitrowebview {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* injectedJavaScript */)>("setInjectedJavaScript");
     method(_javaPart, injectedJavaScript.has_value() ? jni::make_jstring(injectedJavaScript.value()) : nullptr);
   }
+  std::optional<std::string> JHybridNitroWebViewSpec::getInjectedJavaScriptBeforeContentLoaded() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getInjectedJavaScriptBeforeContentLoaded");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
+  }
+  void JHybridNitroWebViewSpec::setInjectedJavaScriptBeforeContentLoaded(const std::optional<std::string>& injectedJavaScriptBeforeContentLoaded) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* injectedJavaScriptBeforeContentLoaded */)>("setInjectedJavaScriptBeforeContentLoaded");
+    method(_javaPart, injectedJavaScriptBeforeContentLoaded.has_value() ? jni::make_jstring(injectedJavaScriptBeforeContentLoaded.value()) : nullptr);
+  }
   std::optional<std::function<void(const WebViewLoadEvent& /* event */)>> JHybridNitroWebViewSpec::getOnLoadStart() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void_WebViewLoadEvent::javaobject>()>("getOnLoadStart_cxx");
     auto __result = method(_javaPart);
@@ -417,6 +426,14 @@ namespace margelo::nitro::nitrowebview {
       });
       return __promise;
     }();
+  }
+  void JHybridNitroWebViewSpec::injectJavaScript(const std::string& code) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* code */)>("injectJavaScript");
+    method(_javaPart, jni::make_jstring(code));
+  }
+  void JHybridNitroWebViewSpec::postMessage(const std::string& data) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* data */)>("postMessage");
+    method(_javaPart, jni::make_jstring(data));
   }
   std::shared_ptr<Promise<std::vector<Cookie>>> JHybridNitroWebViewSpec::getCookies(const std::string& url) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* url */)>("getCookies");

--- a/nitrogen/generated/android/c++/JHybridNitroWebViewSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridNitroWebViewSpec.hpp
@@ -82,6 +82,8 @@ namespace margelo::nitro::nitrowebview {
     void setSharedCookiesEnabled(std::optional<bool> sharedCookiesEnabled) override;
     std::optional<std::string> getInjectedJavaScript() override;
     void setInjectedJavaScript(const std::optional<std::string>& injectedJavaScript) override;
+    std::optional<std::string> getInjectedJavaScriptBeforeContentLoaded() override;
+    void setInjectedJavaScriptBeforeContentLoaded(const std::optional<std::string>& injectedJavaScriptBeforeContentLoaded) override;
     std::optional<std::function<void(const WebViewLoadEvent& /* event */)>> getOnLoadStart() override;
     void setOnLoadStart(const std::optional<std::function<void(const WebViewLoadEvent& /* event */)>>& onLoadStart) override;
     std::optional<std::function<void(const WebViewLoadEvent& /* event */)>> getOnLoadEnd() override;
@@ -104,6 +106,8 @@ namespace margelo::nitro::nitrowebview {
     void reload() override;
     void stopLoading() override;
     std::shared_ptr<Promise<std::string>> evaluateJavaScript(const std::string& code) override;
+    void injectJavaScript(const std::string& code) override;
+    void postMessage(const std::string& data) override;
     std::shared_ptr<Promise<std::vector<Cookie>>> getCookies(const std::string& url) override;
     std::shared_ptr<Promise<void>> setCookie(const std::string& url, const Cookie& cookie) override;
     std::shared_ptr<Promise<void>> clearCookies() override;

--- a/nitrogen/generated/android/c++/views/JHybridNitroWebViewStateUpdater.cpp
+++ b/nitrogen/generated/android/c++/views/JHybridNitroWebViewStateUpdater.cpp
@@ -101,6 +101,10 @@ void JHybridNitroWebViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass
     hybridView->setInjectedJavaScript(props->injectedJavaScript.value);
     props->injectedJavaScript.isDirty = false;
   }
+  if (props->injectedJavaScriptBeforeContentLoaded.isDirty) {
+    hybridView->setInjectedJavaScriptBeforeContentLoaded(props->injectedJavaScriptBeforeContentLoaded.value);
+    props->injectedJavaScriptBeforeContentLoaded.isDirty = false;
+  }
   if (props->onLoadStart.isDirty) {
     hybridView->setOnLoadStart(props->onLoadStart.value);
     props->onLoadStart.isDirty = false;

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrowebview/HybridNitroWebViewSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrowebview/HybridNitroWebViewSpec.kt
@@ -123,6 +123,12 @@ abstract class HybridNitroWebViewSpec: HybridView() {
   @set:Keep
   abstract var injectedJavaScript: String?
   
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
+  abstract var injectedJavaScriptBeforeContentLoaded: String?
+  
   abstract var onLoadStart: ((event: WebViewLoadEvent) -> Unit)?
   
   private var onLoadStart_cxx: Func_void_WebViewLoadEvent?
@@ -241,6 +247,14 @@ abstract class HybridNitroWebViewSpec: HybridView() {
   @DoNotStrip
   @Keep
   abstract fun evaluateJavaScript(code: String): Promise<String>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun injectJavaScript(code: String): Unit
+  
+  @DoNotStrip
+  @Keep
+  abstract fun postMessage(data: String): Unit
   
   @DoNotStrip
   @Keep

--- a/nitrogen/generated/ios/c++/HybridNitroWebViewSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridNitroWebViewSpecSwift.hpp
@@ -218,6 +218,13 @@ namespace margelo::nitro::nitrowebview {
     inline void setInjectedJavaScript(const std::optional<std::string>& injectedJavaScript) noexcept override {
       _swiftPart.setInjectedJavaScript(injectedJavaScript);
     }
+    inline std::optional<std::string> getInjectedJavaScriptBeforeContentLoaded() noexcept override {
+      auto __result = _swiftPart.getInjectedJavaScriptBeforeContentLoaded();
+      return __result;
+    }
+    inline void setInjectedJavaScriptBeforeContentLoaded(const std::optional<std::string>& injectedJavaScriptBeforeContentLoaded) noexcept override {
+      _swiftPart.setInjectedJavaScriptBeforeContentLoaded(injectedJavaScriptBeforeContentLoaded);
+    }
     inline std::optional<std::function<void(const WebViewLoadEvent& /* event */)>> getOnLoadStart() noexcept override {
       auto __result = _swiftPart.getOnLoadStart();
       return __result;
@@ -301,6 +308,18 @@ namespace margelo::nitro::nitrowebview {
       }
       auto __value = std::move(__result.value());
       return __value;
+    }
+    inline void injectJavaScript(const std::string& code) override {
+      auto __result = _swiftPart.injectJavaScript(code);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+    }
+    inline void postMessage(const std::string& data) override {
+      auto __result = _swiftPart.postMessage(data);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
     }
     inline std::shared_ptr<Promise<std::vector<Cookie>>> getCookies(const std::string& url) override {
       auto __result = _swiftPart.getCookies(url);

--- a/nitrogen/generated/ios/c++/views/HybridNitroWebViewComponent.mm
+++ b/nitrogen/generated/ios/c++/views/HybridNitroWebViewComponent.mm
@@ -159,6 +159,11 @@ using namespace margelo::nitro::nitrowebview::views;
     swiftPart.setInjectedJavaScript(newViewProps.injectedJavaScript.value);
     newViewProps.injectedJavaScript.isDirty = false;
   }
+  // injectedJavaScriptBeforeContentLoaded: optional
+  if (newViewProps.injectedJavaScriptBeforeContentLoaded.isDirty) {
+    swiftPart.setInjectedJavaScriptBeforeContentLoaded(newViewProps.injectedJavaScriptBeforeContentLoaded.value);
+    newViewProps.injectedJavaScriptBeforeContentLoaded.isDirty = false;
+  }
   // onLoadStart: optional
   if (newViewProps.onLoadStart.isDirty) {
     swiftPart.setOnLoadStart(newViewProps.onLoadStart.value);

--- a/nitrogen/generated/ios/swift/HybridNitroWebViewSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroWebViewSpec.swift
@@ -26,6 +26,7 @@ public protocol HybridNitroWebViewSpec_protocol: HybridObject, HybridView {
   var thirdPartyCookiesEnabled: Bool? { get set }
   var sharedCookiesEnabled: Bool? { get set }
   var injectedJavaScript: String? { get set }
+  var injectedJavaScriptBeforeContentLoaded: String? { get set }
   var onLoadStart: ((_ event: WebViewLoadEvent) -> Void)? { get set }
   var onLoadEnd: ((_ event: WebViewLoadEvent) -> Void)? { get set }
   var onNavigationStateChange: ((_ state: WebViewNavigationState) -> Void)? { get set }
@@ -40,6 +41,8 @@ public protocol HybridNitroWebViewSpec_protocol: HybridObject, HybridView {
   func reload() throws -> Void
   func stopLoading() throws -> Void
   func evaluateJavaScript(code: String) throws -> Promise<String>
+  func injectJavaScript(code: String) throws -> Void
+  func postMessage(data: String) throws -> Void
   func getCookies(url: String) throws -> Promise<[Cookie]>
   func setCookie(url: String, cookie: Cookie) throws -> Promise<Void>
   func clearCookies() throws -> Promise<Void>

--- a/nitrogen/generated/ios/swift/HybridNitroWebViewSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroWebViewSpec_cxx.swift
@@ -525,6 +525,30 @@ open class HybridNitroWebViewSpec_cxx {
     }
   }
   
+  public final var injectedJavaScriptBeforeContentLoaded: bridge.std__optional_std__string_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_std__string_ in
+        if let __unwrappedValue = self.__implementation.injectedJavaScriptBeforeContentLoaded {
+          return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.injectedJavaScriptBeforeContentLoaded = { () -> String? in
+        if bridge.has_value_std__optional_std__string_(newValue) {
+          let __unwrapped = bridge.get_std__optional_std__string_(newValue)
+          return String(__unwrapped)
+        } else {
+          return nil
+        }
+      }()
+    }
+  }
+  
   public final var onLoadStart: bridge.std__optional_std__function_void_const_WebViewLoadEvent_____event______ {
     @inline(__always)
     get {
@@ -831,6 +855,28 @@ open class HybridNitroWebViewSpec_cxx {
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
       return bridge.create_Result_std__shared_ptr_Promise_std__string___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func injectJavaScript(code: std.string) -> bridge.Result_void_ {
+    do {
+      try self.__implementation.injectJavaScript(code: String(code))
+      return bridge.create_Result_void_()
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_void_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func postMessage(data: std.string) -> bridge.Result_void_ {
+    do {
+      try self.__implementation.postMessage(data: String(data))
+      return bridge.create_Result_void_()
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_void_(__exceptionPtr)
     }
   }
   

--- a/nitrogen/generated/shared/c++/HybridNitroWebViewSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridNitroWebViewSpec.cpp
@@ -46,6 +46,8 @@ namespace margelo::nitro::nitrowebview {
       prototype.registerHybridSetter("sharedCookiesEnabled", &HybridNitroWebViewSpec::setSharedCookiesEnabled);
       prototype.registerHybridGetter("injectedJavaScript", &HybridNitroWebViewSpec::getInjectedJavaScript);
       prototype.registerHybridSetter("injectedJavaScript", &HybridNitroWebViewSpec::setInjectedJavaScript);
+      prototype.registerHybridGetter("injectedJavaScriptBeforeContentLoaded", &HybridNitroWebViewSpec::getInjectedJavaScriptBeforeContentLoaded);
+      prototype.registerHybridSetter("injectedJavaScriptBeforeContentLoaded", &HybridNitroWebViewSpec::setInjectedJavaScriptBeforeContentLoaded);
       prototype.registerHybridGetter("onLoadStart", &HybridNitroWebViewSpec::getOnLoadStart);
       prototype.registerHybridSetter("onLoadStart", &HybridNitroWebViewSpec::setOnLoadStart);
       prototype.registerHybridGetter("onLoadEnd", &HybridNitroWebViewSpec::getOnLoadEnd);
@@ -65,6 +67,8 @@ namespace margelo::nitro::nitrowebview {
       prototype.registerHybridMethod("reload", &HybridNitroWebViewSpec::reload);
       prototype.registerHybridMethod("stopLoading", &HybridNitroWebViewSpec::stopLoading);
       prototype.registerHybridMethod("evaluateJavaScript", &HybridNitroWebViewSpec::evaluateJavaScript);
+      prototype.registerHybridMethod("injectJavaScript", &HybridNitroWebViewSpec::injectJavaScript);
+      prototype.registerHybridMethod("postMessage", &HybridNitroWebViewSpec::postMessage);
       prototype.registerHybridMethod("getCookies", &HybridNitroWebViewSpec::getCookies);
       prototype.registerHybridMethod("setCookie", &HybridNitroWebViewSpec::setCookie);
       prototype.registerHybridMethod("clearCookies", &HybridNitroWebViewSpec::clearCookies);

--- a/nitrogen/generated/shared/c++/HybridNitroWebViewSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitroWebViewSpec.hpp
@@ -108,6 +108,8 @@ namespace margelo::nitro::nitrowebview {
       virtual void setSharedCookiesEnabled(std::optional<bool> sharedCookiesEnabled) = 0;
       virtual std::optional<std::string> getInjectedJavaScript() = 0;
       virtual void setInjectedJavaScript(const std::optional<std::string>& injectedJavaScript) = 0;
+      virtual std::optional<std::string> getInjectedJavaScriptBeforeContentLoaded() = 0;
+      virtual void setInjectedJavaScriptBeforeContentLoaded(const std::optional<std::string>& injectedJavaScriptBeforeContentLoaded) = 0;
       virtual std::optional<std::function<void(const WebViewLoadEvent& /* event */)>> getOnLoadStart() = 0;
       virtual void setOnLoadStart(const std::optional<std::function<void(const WebViewLoadEvent& /* event */)>>& onLoadStart) = 0;
       virtual std::optional<std::function<void(const WebViewLoadEvent& /* event */)>> getOnLoadEnd() = 0;
@@ -130,6 +132,8 @@ namespace margelo::nitro::nitrowebview {
       virtual void reload() = 0;
       virtual void stopLoading() = 0;
       virtual std::shared_ptr<Promise<std::string>> evaluateJavaScript(const std::string& code) = 0;
+      virtual void injectJavaScript(const std::string& code) = 0;
+      virtual void postMessage(const std::string& data) = 0;
       virtual std::shared_ptr<Promise<std::vector<Cookie>>> getCookies(const std::string& url) = 0;
       virtual std::shared_ptr<Promise<void>> setCookie(const std::string& url, const Cookie& cookie) = 0;
       virtual std::shared_ptr<Promise<void>> clearCookies() = 0;

--- a/nitrogen/generated/shared/c++/views/HybridNitroWebViewComponent.cpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroWebViewComponent.cpp
@@ -186,6 +186,16 @@ namespace margelo::nitro::nitrowebview::views {
         throw std::runtime_error(std::string("NitroWebView.injectedJavaScript: ") + exc.what());
       }
     }()),
+    injectedJavaScriptBeforeContentLoaded([&]() -> CachedProp<std::optional<std::string>> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("injectedJavaScriptBeforeContentLoaded", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.injectedJavaScriptBeforeContentLoaded;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<std::optional<std::string>>::fromRawValue(*runtime, value, sourceProps.injectedJavaScriptBeforeContentLoaded);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("NitroWebView.injectedJavaScriptBeforeContentLoaded: ") + exc.what());
+      }
+    }()),
     onLoadStart([&]() -> CachedProp<std::optional<std::function<void(const WebViewLoadEvent& /* event */)>>> {
       try {
         const react::RawValue* rawValue = rawProps.at("onLoadStart", nullptr, nullptr);
@@ -285,6 +295,7 @@ namespace margelo::nitro::nitrowebview::views {
       case hashString("thirdPartyCookiesEnabled"): return true;
       case hashString("sharedCookiesEnabled"): return true;
       case hashString("injectedJavaScript"): return true;
+      case hashString("injectedJavaScriptBeforeContentLoaded"): return true;
       case hashString("onLoadStart"): return true;
       case hashString("onLoadEnd"): return true;
       case hashString("onNavigationStateChange"): return true;

--- a/nitrogen/generated/shared/c++/views/HybridNitroWebViewComponent.hpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroWebViewComponent.hpp
@@ -69,6 +69,7 @@ namespace margelo::nitro::nitrowebview::views {
     CachedProp<std::optional<bool>> thirdPartyCookiesEnabled;
     CachedProp<std::optional<bool>> sharedCookiesEnabled;
     CachedProp<std::optional<std::string>> injectedJavaScript;
+    CachedProp<std::optional<std::string>> injectedJavaScriptBeforeContentLoaded;
     CachedProp<std::optional<std::function<void(const WebViewLoadEvent& /* event */)>>> onLoadStart;
     CachedProp<std::optional<std::function<void(const WebViewLoadEvent& /* event */)>>> onLoadEnd;
     CachedProp<std::optional<std::function<void(const WebViewNavigationState& /* state */)>>> onNavigationStateChange;

--- a/nitrogen/generated/shared/json/NitroWebViewConfig.json
+++ b/nitrogen/generated/shared/json/NitroWebViewConfig.json
@@ -20,6 +20,7 @@
     "thirdPartyCookiesEnabled": true,
     "sharedCookiesEnabled": true,
     "injectedJavaScript": true,
+    "injectedJavaScriptBeforeContentLoaded": true,
     "onLoadStart": true,
     "onLoadEnd": true,
     "onNavigationStateChange": true,

--- a/src/__tests__/post-message-escaping.test.ts
+++ b/src/__tests__/post-message-escaping.test.ts
@@ -1,0 +1,84 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import vm from 'node:vm'
+
+import {
+  buildPostMessageScript,
+  encodeJsStringLiteral,
+} from '../bridgeScript.ts'
+
+const LS = ' '
+const PS = ' '
+
+const HOSTILE: string[] = [
+  '',
+  'plain',
+  'has "double" and \'single\' quotes',
+  'line1\nline2\ttab\r',
+  '</script><script>alert(1)</script>', // must not break out
+  '漢字 🎉 unicode',
+  `sep${LS}here${PS}too`, // JSON.stringify leaves these RAW
+  '{"nested":"json","n":42}',
+  'back\\slash',
+]
+
+test('emitted postMessage statement round-trips every payload as event.data', () => {
+  for (const platform of ['ios', 'android'] as const) {
+    const target = platform === 'ios' ? 'window' : 'document'
+    for (const payload of HOSTILE) {
+      const stmt = buildPostMessageScript(platform, payload)
+
+      // U+2028/U+2029 must be escaped (else pre-ES2019 engines SyntaxError).
+      assert.ok(
+        !stmt.includes(LS) && !stmt.includes(PS),
+        `raw U+2028/U+2029 must not survive into the statement: ${JSON.stringify(payload)}`
+      )
+
+      // The statement must PARSE (Function ctor = same parse the engine does).
+      assert.doesNotThrow(
+        // eslint-disable-next-line no-new-func
+        () => new Function(stmt),
+        `emitted statement must be valid JS for ${JSON.stringify(payload)}`
+      )
+
+      // And it must DELIVER the payload verbatim as event.data.
+      let received: unknown = null
+      const sink = {
+        dispatchEvent(e: { data: unknown }) {
+          received = e.data
+        },
+      }
+      const ctx = vm.createContext({
+        window: platform === 'ios' ? sink : undefined,
+        document: platform === 'android' ? sink : undefined,
+        MessageEvent: class {
+          type: string
+          data: unknown
+          constructor(type: string, init?: { data?: unknown }) {
+            this.type = type
+            this.data = init?.data
+          }
+        },
+      })
+      vm.runInContext(stmt, ctx)
+      assert.equal(
+        received,
+        payload,
+        `${target}.dispatchEvent must carry payload verbatim: ${JSON.stringify(payload)}`
+      )
+    }
+  }
+})
+
+test('encodeJsStringLiteral returns a quoted literal and never emits raw LS/PS', () => {
+  const enc = encodeJsStringLiteral(`a${LS}b${PS}c`)
+  assert.ok(
+    enc.startsWith('"') && enc.endsWith('"'),
+    'must be a quoted JS literal'
+  )
+  assert.ok(
+    enc.includes('\\u2028') && enc.includes('\\u2029'),
+    'LS/PS must be escaped'
+  )
+  assert.ok(!enc.includes(LS) && !enc.includes(PS), 'no raw LS/PS')
+})

--- a/src/bridgeScript.ts
+++ b/src/bridgeScript.ts
@@ -71,6 +71,44 @@ ${routeToNative}
 }
 
 /**
+ * Escape a string for safe embedding inside a JavaScript *source* string.
+ *
+ * `JSON.stringify` handles quotes, backslashes, newlines, and control chars,
+ * and produces a valid double-quoted JS string literal for them. BUT it
+ * leaves U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) RAW: they
+ * are legal in JSON yet illegal *unescaped* inside a JS string literal on
+ * pre-ES2019 engines (older Android System WebView / older iOS JSC will
+ * throw a SyntaxError when the injected statement is parsed). We post-escape
+ * those two code points so the emitted statement always parses.
+ *
+ * Returns a quoted JS string literal (includes the surrounding quotes).
+ */
+export function encodeJsStringLiteral(value: string): string {
+  return JSON.stringify(value)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+}
+
+/**
+ * Build the one-shot JS statement that delivers a native→web message as a
+ * DOM `message` event, matching react-native-webview's drop-in contract.
+ *
+ *   - iOS     → dispatch on `window`   (RNCWebViewImpl.m:1113)
+ *   - Android → dispatch on `document` (RNCWebViewManagerImpl.kt:335)
+ *
+ * `event.data` is `message` verbatim. The statement is self-contained and
+ * fire-and-forget; the caller evaluates it with no completion handler.
+ */
+export function buildPostMessageScript(
+  platform: BridgePlatform,
+  message: string
+): string {
+  const target = platform === 'ios' ? 'window' : 'document'
+  const data = encodeJsStringLiteral(message)
+  return `${target}.dispatchEvent(new MessageEvent('message',{data:${data}}));`
+}
+
+/**
  * Sandbox shape for evaluating the iOS bridge script.
  */
 export interface IosBridgeSandbox {

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,8 @@ export {
   ANDROID_NATIVE_BRIDGE_NAME,
   BRIDGE_NAME,
   buildBridgeScript,
+  buildPostMessageScript,
+  encodeJsStringLiteral,
   evaluateBridgeScript,
 } from './bridgeScript'
 export type {

--- a/src/specs/NitroWebView.nitro.ts
+++ b/src/specs/NitroWebView.nitro.ts
@@ -322,6 +322,33 @@ export interface NitroWebViewProps extends HybridViewProps {
   /** JavaScript auto-injected on every page load (fire-and-forget). */
   injectedJavaScript?: string
 
+  /**
+   * JavaScript injected **before** the page's own content/scripts run, on
+   * every main-frame load (fire-and-forget). Use this for shims a page
+   * expects to exist at startup (feature detection, `window` globals).
+   * `injectedJavaScript` (above) runs at document-END instead.
+   *
+   * Timing guarantee (differs by platform — read carefully):
+   *   - iOS (WKWebView): injected as a `WKUserScript` with
+   *     `injectionTime = .atDocumentStart`, `forMainFrameOnly = true`.
+   *     WebKit runs it after the document element exists but BEFORE any
+   *     page script — a hard ordering guarantee.
+   *   - Android (android.webkit.WebView): when the device's WebView supports
+   *     the `DOCUMENT_START_SCRIPT` feature, injected via
+   *     `WebViewCompat.addDocumentStartJavaScript` before `loadUrl` — the
+   *     same before-any-page-script guarantee as iOS. On older WebViews
+   *     lacking that feature it falls back to `WebView.evaluateJavascript`
+   *     inside `WebViewClient.onPageStarted`, which is "early enough" for
+   *     shim installation in practice but is NOT a strict
+   *     before-first-script guarantee — a page whose very first inline
+   *     `<script>` runs synchronously during initial parse can race it.
+   *
+   * Applied to the main frame only on both platforms. Changing this prop
+   * takes effect on the next navigation (it is not re-run against the
+   * currently-loaded page).
+   */
+  injectedJavaScriptBeforeContentLoaded?: string
+
   /** Fired when the WebView begins loading content. */
   onLoadStart?: (event: WebViewLoadEvent) => void
 
@@ -407,6 +434,39 @@ export interface NitroWebViewMethods extends HybridViewMethods {
    * as the empty string.
    */
   evaluateJavaScript(code: string): Promise<string>
+
+  /**
+   * Fire-and-forget JavaScript execution inside the WebView's main frame.
+   * Unlike {@linkcode evaluateJavaScript}, this returns nothing and never
+   * awaits a result — use it when you only need a side effect.
+   *
+   *   - iOS: `WKWebView.evaluateJavaScript(code, completionHandler: nil)`.
+   *   - Android: `WebView.evaluateJavascript(code, null)`.
+   *
+   * `code` runs in the page's JS context at call time; if no page is
+   * loaded yet the call is a no-op. No value, error, or completion signal
+   * is surfaced to JS (react-native-webview `injectJavaScript` parity).
+   */
+  injectJavaScript(code: string): void
+
+  /**
+   * Push a string from native INTO the page. The page receives it as a
+   * DOM `message` event whose `event.data` is `data` verbatim.
+   *
+   * Page-side contract (react-native-webview drop-in — platform-asymmetric,
+   * so register on BOTH targets to be portable):
+   *   - iOS delivers via `window.dispatchEvent(new MessageEvent('message', {data}))`
+   *     → listen with `window.addEventListener('message', e => e.data)`.
+   *   - Android delivers via `document.dispatchEvent(new MessageEvent('message', {data}))`
+   *     → listen with `document.addEventListener('message', e => e.data)`.
+   *
+   * Delivery is fire-and-forget and synchronous-at-eval: it dispatches
+   * once, immediately. A listener the page registers AFTER this call will
+   * NOT receive the message (no buffering / replay). `data` may contain
+   * any characters — quotes, newlines, `</script>`, and unicode are
+   * escaped safely before injection (see native `postMessage` escaping).
+   */
+  postMessage(data: string): void
 
   /**
    * Return every cookie the platform's shared cookie store holds for the


### PR DESCRIPTION
## Summary

Adds react-native-webview-compatible JS injection and native↔web messaging, all thin wrappers over primitives already in both native files.

- `injectedJavaScriptBeforeContentLoaded` prop (string) — document-start injection.
  - iOS: a `WKUserScript` at `.atDocumentStart` (main frame), ordered after the bridge bootstrap. A shared `reinstallUserScripts()` re-registers bridge → before-content → injected (document-end) in a fixed order on any prop change.
  - Android: `WebViewCompat.addDocumentStartJavaScript` when the device WebView supports `DOCUMENT_START_SCRIPT` (before-any-page-script guarantee, matching iOS), else falls back to `evaluateJavascript` in `onPageStarted`.
- `injectJavaScript(code)` method — fire-and-forget, returns `void` (contrast `evaluateJavaScript`, which stays `Promise<string>`).
- `postMessage(data)` method — native→web delivery. Platform-asymmetric target matching RNW: iOS dispatches a DOM `message` event on `window`, Android on `document`. Page authors listen on both for portability.

The one non-trivial concern is escaping an arbitrary payload into a JS source string. A shared `encodeJsStringLiteral` uses `JSON.stringify` (JS) / `JSONObject.quote` (Kotlin) / `JSONSerialization` (Swift), then post-escapes U+2028 / U+2029 — these are legal in JSON but illegal *unescaped* inside a JS string literal on pre-ES2019 engines, which would throw a `SyntaxError` at inject time. The pure-TS builder is the canonical oracle; the two native mirrors are asserted against the same shape.

### New dependency

Adds `androidx.webkit:webkit:1.14.0` to `android/build.gradle` for `WebViewCompat.addDocumentStartJavaScript` / `WebViewFeature.DOCUMENT_START_SCRIPT`. react-native-webview already depends on this artifact. Consumers gain a transitive androidx.webkit dependency.

## Test plan

- **TypeScript**: `yarn test` — 257 pass (incl. new `post-message-escaping.test.ts`: 9 hostile payloads incl. quotes / newlines / `</script>` / unicode / U+2028 / U+2029, asserting no raw LS/PS survive, `new Function(stmt)` parses, and a `vm` sandbox delivers each payload verbatim as `event.data`). `yarn typecheck` and `yarn lint` clean.
- **iOS**: `swift test` — 119 pass (incl. new `HybridNitroWebViewPostMessageTests`: statement shape, no raw LS/PS, verbatim round-trip through JSON decode).
- **Android**: `:nitro-webview:testDebugUnitTest` — 111 pass (incl. new Robolectric-run `HybridNitroWebViewPostMessageTest` so real `org.json.JSONObject.quote` is used). Library compiles against the new androidx.webkit dependency.
- Not verified: on-device before-content injection ordering and `postMessage` delivery against a live page (no unit surface — requires an emulator/device run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for injecting JavaScript before page content loads.
  * Added imperative methods to execute JavaScript and send DOM `message` events to web content.
  * Added safe handling for special characters in posted message data.
  * Expanded API documentation for script injection and WebView methods.

* **Tests**
  * Added coverage for JavaScript execution, message delivery, payload escaping, and cross-platform behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->