### PR TITLE
feat: imperative methods (clearCache/clearHistory/requestFocus) + blob download support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -220,5 +220,19 @@ let package = Package(
       dependencies: ["NitroWebViewSource"],
       path: "iosTests/Tests/HybridNitroWebViewHttpErrorTests"
     ),
+    .testTarget(
+      // Exercises the imperative-method + blob-download helpers:
+      //   1. `cacheDataTypes()` — the cache-only record set clearCache uses
+      //      (disk + memory only, never cookies/localStorage).
+      //   2. `isBlobDownload(response:canShowMIMEType:)` — routes a blob:
+      //      navigation response to WKDownloadDelegate.
+      //   3. `NavigationDelegate.blobDownloadDestination(suggestedFilename:)`
+      //      — the unique, non-existent temp-file path a blob is written to.
+      // Uses probe mirrors because the production class cannot be linked
+      // into this SwiftPM host harness.
+      name: "HybridNitroWebViewImperativeMethodsTests",
+      dependencies: ["NitroWebViewSource"],
+      path: "iosTests/Tests/HybridNitroWebViewImperativeMethodsTests"
+    ),
   ]
 )

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The exported React component. Backed by `getHostComponent<NitroWebViewProps, Nit
 | `onNavigationStateChange` | `(state: WebViewNavigationState) => void` | URL / title / `canGoBack` / `canGoForward` / `loading`. |
 | `onMessage` | `(event: WebViewMessageEvent) => void` | Fires when the page calls `window.ReactNativeWebView.postMessage(...)`. |
 | `onError` | `(event: NitroWebViewErrorEvent) => void` | Navigation failure (network, SSL). |
-| `onFileDownload` | `(event: FileDownloadEvent) => void` | Native intercepts a download and surfaces `{ url, mimeType?, fileName?, contentLength?, userAgent? }`. Storage is the JS layer's responsibility. |
+| `onFileDownload` | `(event: FileDownloadEvent) => void` | Native intercepts a download and surfaces `{ url, mimeType?, fileName?, contentLength?, userAgent? }`. Storage is the JS layer's responsibility. Also fires for `blob:` downloads, with `url` resolved to a local `file://` (iOS) / `data:` (Android) URL — see [`FileDownload`](#filedownload--filedownloadevent). |
 | `onHttpError` | `(event: NitroWebViewHttpErrorEvent) => void` | Main-frame HTTP 4xx/5xx (`{ statusCode, url, description }`). Disjoint from `onError` (transport/SSL). Sub-resource failures are dropped. |
 | `onRenderProcessGone` | `(event: NitroWebViewRenderProcessGoneEvent) => void` | Renderer crash / OS reclaim. `nativeEvent.didCrash` is Android-only (API 26+); always `undefined` on iOS. Recover by calling `reload()`. |
 | `onScroll` | `(event: NitroWebViewScrollEvent) => void` | Scroll stream. NOT throttled or deduped natively. iOS populates all geometry fields; Android populates `contentOffset` only. |
@@ -149,6 +149,9 @@ The hybrid ref captured by `hybridRef={callback((r) => ref.current = r)}` expose
 | `getCookies(url)` | `Promise<Cookie[]>` | iOS returns the full attribute set. Android `CookieManager` only exposes `name` and `value` on read — other fields are left `undefined`. |
 | `setCookie(url, cookie)` | `Promise<void>` | `Cookie = { name, value, domain?, path?, expires?, secure?, httpOnly? }`. `expires` is milliseconds since epoch (`Date.now()`-compatible). |
 | `clearCookies()` | `Promise<void>` | Bulk clear via `WKWebsiteDataStore` (iOS) / `CookieManager.removeAllCookies` (Android). The promise resolves only after the platform reports completion. |
+| `clearCache()` | `Promise<void>` | Clear the disk + memory resource cache only (NOT cookies/localStorage/history). iOS scopes `removeData` to `{DiskCache, MemoryCache}`; Android calls `clearCache(true)`. |
+| `clearHistory()` | `Promise<void>` | Clear back/forward history. Android: `WebView.clearHistory()`. **iOS: no-op** — `WKWebView.backForwardList` is read-only with no public prune API (resolves without clearing; navigate to a fresh `source` for a pristine stack). |
+| `requestFocus()` | `Promise<void>` | Move input focus to the WebView. iOS `becomeFirstResponder()`; Android `requestFocus()`. Resolves regardless of the responder's own return value. |
 
 ### Types
 
@@ -254,7 +257,8 @@ interface Cookie {
 
 ```ts
 interface FileDownload {
-  url: string             // always http/https — blob: URLs are out of scope
+  url: string             // normal download: remote http/https URL.
+                          // blob download: a resolved LOCAL reference (see below).
   mimeType?: string
   fileName?: string       // iOS: URLResponse.suggestedFilename
                           // Android: DownloadUtils.guessFileName (Content-Disposition)
@@ -266,6 +270,22 @@ interface FileDownloadEvent {
   nativeEvent: FileDownload
 }
 ```
+
+**Blob downloads (`blob:`) — deliberately platform-asymmetric.** A `blob:`
+URL is not fetchable natively (its bytes live only in the web context), so the
+two platforms resolve it differently and `onFileDownload.nativeEvent.url`
+carries a **local** reference instead of the `blob:` URL:
+
+- **iOS** streams the blob to a temp file natively via `WKDownloadDelegate`
+  (iOS 14.5+) — `url` is a local `file://` URL. No bytes cross the JS bridge.
+- **Android** has no `WKDownloadDelegate` equivalent, so it injects a reader
+  that resolves the blob in-page (`fetch → FileReader.readAsDataURL`) and
+  bridges it back — `url` is a `data:` URL (base64). This is O(fileSize) in
+  memory; fine for the common blob (generated CSV/PDF/image, a few MB), but a
+  very large blob will strain the bridge.
+
+Either way a consumer already listening to `onFileDownload` receives blob
+downloads for free (no extra prop) and can `fetch()`/save `url` uniformly.
 
 ### Origin whitelist helpers
 

--- a/android/src/main/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebView.kt
+++ b/android/src/main/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebView.kt
@@ -844,12 +844,8 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
    * we fall back to the platform's [URLUtil.guessFileName] which is the
    * historic default the AOSP DownloadManager uses.
    *
-   * `blob:` URLs cannot be fetched natively (the bytes live only in the web
-   * context), so they take a JS-inject path instead: a reader script fetches
-   * the blob in-page, reads it to a data URL, and posts a reserved envelope
-   * back through the existing message bridge. [BridgeInterface.postMessage]
-   * demuxes that envelope and emits `onFileDownload` with the data URL. See
-   * [buildBlobReaderScript] / [parseBlobEnvelope] (the canonical TS source).
+   * `blob:` URLs cannot be fetched natively and take a JS-inject path; see
+   * the inline note below and [buildBlobReaderScript] / [parseBlobEnvelope].
    */
   private inner class DownloadListenerImpl : DownloadListener {
     override fun onDownloadStart(
@@ -1232,15 +1228,10 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
     )
 
     /**
-     * Build the reader script injected into the page to resolve a `blob:`
-     * URL (its bytes live only in the web context). Kotlin port of
-     * `buildBlobReaderScript` in `src/bridgeScript.ts` — MUST stay behavior-
-     * identical: `fetch(blob) → .blob() → FileReader.readAsDataURL` → post a
-     * reserved envelope through the existing `ReactNativeWebView.postMessage`
-     * bridge. Every failure path swallows so the page never throws.
-     *
-     * `suggestedName` is native-derived (usually junk off the blob URL); the
-     * page's real download name is not recoverable from a bare blob: URL.
+     * Injects the in-page reader that resolves a `blob:` URL to a data URL and
+     * posts a reserved envelope back through the message bridge; the envelope
+     * must match `parseBlobEnvelope`'s contract in `src/bridgeScript.ts`.
+     * `suggestedName` is native-derived (usually junk off the blob URL).
      */
     @JvmStatic
     internal fun buildBlobReaderScript(blobUrl: String, suggestedName: String): String {

--- a/android/src/main/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebView.kt
+++ b/android/src/main/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebView.kt
@@ -366,6 +366,33 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
     view.post { view.stopLoading() }
   }
 
+  override fun clearCache(): Promise<Unit> {
+    val promise = Promise<Unit>()
+    view.post {
+      view.clearCache(true) // true = also delete on-disk cache files
+      promise.resolve(Unit)
+    }
+    return promise
+  }
+
+  override fun clearHistory(): Promise<Unit> {
+    val promise = Promise<Unit>()
+    view.post {
+      view.clearHistory()
+      promise.resolve(Unit)
+    }
+    return promise
+  }
+
+  override fun requestFocus(): Promise<Unit> {
+    val promise = Promise<Unit>()
+    view.post {
+      view.requestFocus() // View.requestFocus(): Boolean — discard
+      promise.resolve(Unit)
+    }
+    return promise
+  }
+
   override fun evaluateJavaScript(code: String): Promise<String> {
     val promise = Promise<String>()
     view.post {
@@ -768,6 +795,26 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
     fun postMessage(data: String) {
       // @JavascriptInterface runs on a dedicated `JavaBridge` thread.
       // WebView.url / onMessage delivery must hop back to the UI thread.
+      // Peek for a reserved blob-download envelope BEFORE treating the
+      // payload as a normal onMessage string — a real download is routed to
+      // onFileDownload, everything else falls through unchanged.
+      val blob = parseBlobEnvelope(data)
+      if (blob != null) {
+        view.post {
+          // The data URL is the ONE place a data: URL is a legitimate
+          // FileDownload.url (blob bytes bridged in-band as base64).
+          emitFileDownload(
+            FileDownload(
+              url = blob.dataUrl,
+              mimeType = blob.mimeType.takeIf { it.isNotEmpty() },
+              fileName = blob.fileName.takeIf { it.isNotEmpty() },
+              contentLength = blob.size.takeIf { it > 0 },
+              userAgent = null,
+            ),
+          )
+        }
+        return
+      }
       view.post {
         val payload = WebViewMessageEvent(
           WebViewMessageNativeEvent(
@@ -797,7 +844,12 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
    * we fall back to the platform's [URLUtil.guessFileName] which is the
    * historic default the AOSP DownloadManager uses.
    *
-   * The MVP excludes blob URLs by short-circuiting `blob:` schemes.
+   * `blob:` URLs cannot be fetched natively (the bytes live only in the web
+   * context), so they take a JS-inject path instead: a reader script fetches
+   * the blob in-page, reads it to a data URL, and posts a reserved envelope
+   * back through the existing message bridge. [BridgeInterface.postMessage]
+   * demuxes that envelope and emits `onFileDownload` with the data URL. See
+   * [buildBlobReaderScript] / [parseBlobEnvelope] (the canonical TS source).
    */
   private inner class DownloadListenerImpl : DownloadListener {
     override fun onDownloadStart(
@@ -808,8 +860,16 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
       contentLength: Long,
     ) {
       if (url == null) return
-      // blob: URLs are out of scope for the MVP.
-      if (url.startsWith("blob:")) return
+      // blob: bytes live only in the web context — inject a reader that
+      // resolves the blob to a data URL and posts it back through the bridge
+      // (demuxed in BridgeInterface.postMessage). The real onFileDownload is
+      // emitted from there, not here.
+      if (url.startsWith("blob:")) {
+        val guessed = deriveDownloadFileName(url, contentDisposition, mimetype)
+        val js = buildBlobReaderScript(url, guessed)
+        view.post { view.evaluateJavascript(js, null) }
+        return
+      }
       val fileName = deriveDownloadFileName(url, contentDisposition, mimetype)
       val event = FileDownload(
         url = url,
@@ -1150,6 +1210,111 @@ class HybridNitroWebView(context: ThemedReactContext) : HybridNitroWebViewSpec()
       }
       return out.toTypedArray()
     }
+
+    /**
+     * Reserved discriminator key for blob-download payloads. Kept in sync
+     * with `BLOB_ENVELOPE_KEY` in `src/bridgeScript.ts` (the canonical TS
+     * source). A payload literally starting with `{"__nitro_blob__"` is
+     * demuxed to `onFileDownload`; everything else is a normal `onMessage`.
+     */
+    internal const val BLOB_ENVELOPE_KEY = "__nitro_blob__"
+
+    /**
+     * Parsed blob-download payload. Mirrors `BlobDownloadPayload` in
+     * `src/bridgeScript.ts`.
+     */
+    internal data class BlobEnvelope(
+      val url: String,
+      val dataUrl: String,
+      val mimeType: String,
+      val fileName: String,
+      val size: Double,
+    )
+
+    /**
+     * Build the reader script injected into the page to resolve a `blob:`
+     * URL (its bytes live only in the web context). Kotlin port of
+     * `buildBlobReaderScript` in `src/bridgeScript.ts` — MUST stay behavior-
+     * identical: `fetch(blob) → .blob() → FileReader.readAsDataURL` → post a
+     * reserved envelope through the existing `ReactNativeWebView.postMessage`
+     * bridge. Every failure path swallows so the page never throws.
+     *
+     * `suggestedName` is native-derived (usually junk off the blob URL); the
+     * page's real download name is not recoverable from a bare blob: URL.
+     */
+    @JvmStatic
+    internal fun buildBlobReaderScript(blobUrl: String, suggestedName: String): String {
+      val urlLit = jsonQuote(blobUrl)
+      val nameLit = jsonQuote(suggestedName)
+      val keyLit = jsonQuote(BLOB_ENVELOPE_KEY)
+      return """;(function () {
+  try {
+    fetch($urlLit).then(function (r) { return r.blob(); }).then(function (b) {
+      var reader = new FileReader();
+      reader.onloadend = function () {
+        var dataUrl = String(reader.result || '');
+        var envelope = {};
+        envelope[$keyLit] = {
+          url: $urlLit,
+          dataUrl: dataUrl,
+          mimeType: b.type || '',
+          fileName: $nameLit,
+          size: b.size || 0
+        };
+        var br = window.$BRIDGE_NAME;
+        if (br && typeof br.postMessage === 'function') {
+          br.postMessage(JSON.stringify(envelope));
+        }
+      };
+      reader.readAsDataURL(b);
+    })["catch"](function () { /* blob gone / cross-origin: swallow */ });
+  } catch (e) { /* no fetch/FileReader: swallow, no page throw */ }
+})();"""
+    }
+
+    /**
+     * Parse a raw `postMessage` string; return the blob payload or `null`
+     * when it is a normal `onMessage` payload. Kotlin port of
+     * `parseBlobEnvelope` in `src/bridgeScript.ts`. A cheap prefix peek runs
+     * before the JSON parse so ordinary payloads are forwarded untouched.
+     *
+     * ponytail: the whole blob rides the bridge base64'd (data URL) —
+     * O(fileSize) memory, ~1.33x inflation, held twice (JS string + native
+     * String). Fine for the common blob (generated CSV/PDF/image, a few MB);
+     * a very large blob will strain the bridge. Upgrade path: temp-file
+     * streaming (slice the blob and post chunks, or a native download to
+     * disk) surfacing a `file://` URL instead of a data: URL.
+     */
+    @JvmStatic
+    internal fun parseBlobEnvelope(raw: String?): BlobEnvelope? {
+      if (raw == null) return null
+      if (!raw.startsWith("{\"$BLOB_ENVELOPE_KEY\"")) return null
+      return try {
+        val root = org.json.JSONObject(raw)
+        val b = root.optJSONObject(BLOB_ENVELOPE_KEY) ?: return null
+        val url = b.optString("url", "")
+        val dataUrl = b.optString("dataUrl", "")
+        if (url.isEmpty() || dataUrl.isEmpty()) return null
+        BlobEnvelope(
+          url = url,
+          dataUrl = dataUrl,
+          mimeType = b.optString("mimeType", ""),
+          fileName = b.optString("fileName", ""),
+          size = b.optDouble("size", 0.0),
+        )
+      } catch (e: org.json.JSONException) {
+        null
+      }
+    }
+
+    /**
+     * Minimal JSON string-literal encoder for the values embedded in the
+     * blob reader script. `org.json.JSONObject.quote` handles the escaping
+     * (quotes, backslashes, control chars) the same way `JSON.stringify`
+     * does for a bare string in the TS source.
+     */
+    @JvmStatic
+    internal fun jsonQuote(s: String): String = org.json.JSONObject.quote(s)
 
     /**
      * Pipeline that mirrors the per-instance [setCookie] body 1:1 but

--- a/android/src/test/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebViewBlobEnvelopeTest.kt
+++ b/android/src/test/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebViewBlobEnvelopeTest.kt
@@ -1,0 +1,100 @@
+package io.github.l2hyunwoo.nitro.webview
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * JVM/Robolectric tests for the Android blob-download demux on
+ * [HybridNitroWebView.Companion]:
+ *
+ *   - `buildBlobReaderScript` — the JS injected into the page to read a
+ *     `blob:` URL to a data URL and post a reserved envelope.
+ *   - `parseBlobEnvelope` — the demux the message sink runs to route that
+ *     envelope to `onFileDownload` instead of `onMessage`.
+ *
+ * These MUST stay behavior-identical to the canonical TS source in
+ * `src/bridgeScript.ts` (whose own round-trip is covered by
+ * `src/__tests__/blob-reader-envelope.test.ts`). Robolectric supplies the
+ * real `org.json` used by both helpers (the plain JVM stub throws).
+ */
+@RunWith(RobolectricTestRunner::class)
+class HybridNitroWebViewBlobEnvelopeTest {
+
+  // region: parseBlobEnvelope — happy path
+
+  @Test
+  fun `parseBlobEnvelope_returnsPayload_forWellFormedEnvelope`() {
+    val raw =
+      """{"__nitro_blob__":{"url":"blob:https://x/abc","dataUrl":"data:application/pdf;base64,JVBERg==","mimeType":"application/pdf","fileName":"report.pdf","size":5}}"""
+    val parsed = HybridNitroWebView.parseBlobEnvelope(raw)
+    assertNotNull(parsed)
+    assertEquals("blob:https://x/abc", parsed!!.url)
+    assertEquals("data:application/pdf;base64,JVBERg==", parsed.dataUrl)
+    assertEquals("application/pdf", parsed.mimeType)
+    assertEquals("report.pdf", parsed.fileName)
+    assertEquals(5.0, parsed.size, 0.0)
+  }
+
+  @Test
+  fun `parseBlobEnvelope_defaultsOptionalFields_whenAbsent`() {
+    val raw = """{"__nitro_blob__":{"url":"blob:https://x/1","dataUrl":"data:;base64,"}}"""
+    val parsed = HybridNitroWebView.parseBlobEnvelope(raw)
+    assertNotNull(parsed)
+    assertEquals("", parsed!!.mimeType)
+    assertEquals("", parsed.fileName)
+    assertEquals(0.0, parsed.size, 0.0)
+  }
+
+  // region: parseBlobEnvelope — channel isolation (normal onMessage falls through)
+
+  @Test
+  fun `parseBlobEnvelope_returnsNull_forNormalOnMessagePayloads`() {
+    assertNull(HybridNitroWebView.parseBlobEnvelope("hello"))
+    assertNull(HybridNitroWebView.parseBlobEnvelope(""))
+    assertNull(HybridNitroWebView.parseBlobEnvelope("""{"k":"v"}"""))
+    assertNull(HybridNitroWebView.parseBlobEnvelope(null))
+  }
+
+  @Test
+  fun `parseBlobEnvelope_returnsNull_whenKeyAppearsAsAValueElsewhere`() {
+    // The reserved key appearing as a VALUE must not be mistaken for an envelope.
+    assertNull(HybridNitroWebView.parseBlobEnvelope("""{"user":"__nitro_blob__"}"""))
+  }
+
+  @Test
+  fun `parseBlobEnvelope_returnsNull_forMalformedEnvelope`() {
+    // Matching prefix but missing required url/dataUrl.
+    assertNull(HybridNitroWebView.parseBlobEnvelope("""{"__nitro_blob__":{}}"""))
+    // Matching prefix but invalid JSON — must return null, never throw.
+    assertNull(HybridNitroWebView.parseBlobEnvelope("""{"__nitro_blob__"broken"""))
+  }
+
+  // region: buildBlobReaderScript
+
+  @Test
+  fun `buildBlobReaderScript_embedsBridgeAndReservedKey`() {
+    val js = HybridNitroWebView.buildBlobReaderScript("blob:https://x/abc", "report.pdf")
+    assertTrue("must fetch the blob url", js.contains("blob:https://x/abc"))
+    assertTrue("must read as data url", js.contains("readAsDataURL"))
+    assertTrue("must post the reserved key", js.contains("__nitro_blob__"))
+    assertTrue(
+      "must route through the existing bridge",
+      js.contains("window.ReactNativeWebView"),
+    )
+  }
+
+  @Test
+  fun `buildBlobReaderScript_jsonEncodesInputs_soQuotesCannotBreakOut`() {
+    // A URL/name with quotes+backslashes must be JSON-encoded so it cannot
+    // terminate the source-string literal.
+    val js = HybridNitroWebView.buildBlobReaderScript("""blob:https://x/a"b\c""", """n"a\me""")
+    // The raw unescaped forms must NOT appear verbatim; the escaped forms must.
+    assertTrue(js.contains("""blob:https://x/a\"b\\c"""))
+    assertTrue(js.contains("""n\"a\\me"""))
+  }
+}

--- a/android/src/test/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebViewBlobEnvelopeTest.kt
+++ b/android/src/test/java/io/github/l2hyunwoo/nitro/webview/HybridNitroWebViewBlobEnvelopeTest.kt
@@ -79,7 +79,10 @@ class HybridNitroWebViewBlobEnvelopeTest {
   @Test
   fun `buildBlobReaderScript_embedsBridgeAndReservedKey`() {
     val js = HybridNitroWebView.buildBlobReaderScript("blob:https://x/abc", "report.pdf")
-    assertTrue("must fetch the blob url", js.contains("blob:https://x/abc"))
+    // org.json.JSONObject.quote escapes '/' as '\/' per the JSON spec (both
+    // are valid inside a JS string literal and decode to the same character;
+    // only the SOURCE representation differs from the raw URL).
+    assertTrue("must fetch the blob url", js.contains("blob:https:\\/\\/x\\/abc"))
     assertTrue("must read as data url", js.contains("readAsDataURL"))
     assertTrue("must post the reserved key", js.contains("__nitro_blob__"))
     assertTrue(
@@ -91,10 +94,11 @@ class HybridNitroWebViewBlobEnvelopeTest {
   @Test
   fun `buildBlobReaderScript_jsonEncodesInputs_soQuotesCannotBreakOut`() {
     // A URL/name with quotes+backslashes must be JSON-encoded so it cannot
-    // terminate the source-string literal.
+    // terminate the source-string literal. '/' is also escaped as '\/' by
+    // org.json.JSONObject.quote (see the sibling test above).
     val js = HybridNitroWebView.buildBlobReaderScript("""blob:https://x/a"b\c""", """n"a\me""")
     // The raw unescaped forms must NOT appear verbatim; the escaped forms must.
-    assertTrue(js.contains("""blob:https://x/a\"b\\c"""))
+    assertTrue(js.contains("""blob:https:\/\/x\/a\"b\\c"""))
     assertTrue(js.contains("""n\"a\\me"""))
   }
 }

--- a/ios/HybridNitroWebView.swift
+++ b/ios/HybridNitroWebView.swift
@@ -180,6 +180,49 @@ final class HybridNitroWebView:
   func reload() throws { view.reload() }
   func stopLoading() throws { view.stopLoading() }
 
+  /// Clear the cache-shaped record types from the view's data store. The set
+  /// is deliberately cache-only (`Self.cacheDataTypes()`) — using
+  /// `allWebsiteDataTypes()` would also wipe cookies/localStorage.
+  func clearCache() throws -> Promise<Void> {
+    let promise = Promise<Void>()
+    view.configuration.websiteDataStore.removeData(
+      ofTypes: Self.cacheDataTypes(),
+      modifiedSince: .distantPast
+    ) {
+      promise.resolve(withResult: ())
+    }
+    return promise
+  }
+
+  /// Documented no-op: `WKWebView.backForwardList` is read-only with no
+  /// public prune/clear API. Resolves so the cross-platform `Promise<void>`
+  /// contract still settles (react-native-webview exposes `clearHistory` on
+  /// Android only). See the spec JSDoc.
+  func clearHistory() throws -> Promise<Void> {
+    let promise = Promise<Void>()
+    promise.resolve(withResult: ())
+    return promise
+  }
+
+  func requestFocus() throws -> Promise<Void> {
+    let promise = Promise<Void>()
+    // becomeFirstResponder must run on the main thread. Discard the Bool:
+    // `false` means "already first responder / window not key", not an error.
+    DispatchQueue.main.async {
+      _ = self.view.becomeFirstResponder()
+      promise.resolve(withResult: ())
+    }
+    return promise
+  }
+
+  /// Cache-only website-data record types for `clearCache()`. Standalone
+  /// static helper so host-side XCTest can pin the exact `Set<String>`
+  /// (`{disk, memory}`) without a live `WKWebView` — same rationale as
+  /// `shouldTreatAsDownload`. Deliberately excludes cookies/localStorage.
+  static func cacheDataTypes() -> Set<String> {
+    [WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache]
+  }
+
   func evaluateJavaScript(code: String) throws -> Promise<String> {
     let promise = Promise<String>()
     evaluator.evaluate(
@@ -404,6 +447,33 @@ final class HybridNitroWebView:
     /// react-native-webview's iOS lockIdentifier round-trip semantics.
     private var pendingDecisions: [ObjectIdentifier: (WKNavigationActionPolicy) -> Void] = [:]
 
+    /// In-flight blob downloads keyed by `WKDownload` identity. Holds the
+    /// chosen temp-file destination + the download's response so
+    /// `downloadDidFinish` (which receives only the `WKDownload`) can emit
+    /// `onFileDownload` with the local file URL + distilled metadata.
+    fileprivate var pendingDownloads: [ObjectIdentifier: (url: URL, response: URLResponse?)] = [:]
+
+    /// Pick a unique, non-existent temp-file destination for a blob download.
+    /// `WKDownload` requires a path that does NOT already exist, so each
+    /// download gets its own UUID subdirectory — concurrent / repeated
+    /// downloads of the same filename never collide. Returns `nil` when the
+    /// destination directory cannot be created. Standalone static helper so
+    /// host-side XCTest can pin the path shape without a live `WKDownload`.
+    static func blobDownloadDestination(suggestedFilename: String) -> URL? {
+      let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("nitro-webview-blob", isDirectory: true)
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+      do {
+        try FileManager.default.createDirectory(
+          at: dir, withIntermediateDirectories: true
+        )
+      } catch {
+        return nil
+      }
+      let name = suggestedFilename.isEmpty ? "download" : suggestedFilename
+      return dir.appendingPathComponent(name)
+    }
+
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
       owner?.emitLoadStart()
       owner?.emitNavigationState()
@@ -475,6 +545,17 @@ final class HybridNitroWebView:
       decidePolicyFor navigationResponse: WKNavigationResponse,
       decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
     ) {
+      // Blob downloads take the native `WKDownloadDelegate` path: return
+      // `.download` so WebKit streams the bytes to a temp file (no
+      // base64-over-bridge), then emit `onFileDownload` with the local
+      // `file://` URL from `download(_:didFinishDownloading:)`.
+      if HybridNitroWebView.isBlobDownload(
+        response: navigationResponse.response,
+        canShowMIMEType: navigationResponse.canShowMIMEType
+      ) {
+        decisionHandler(.download)
+        return
+      }
       let httpResponse = navigationResponse.response as? HTTPURLResponse
       // HTTP-error (4xx/5xx) detection for the MAIN frame only. Disjoint from
       // `onError` (transport failures). Emitted BEFORE the download branch and
@@ -508,6 +589,17 @@ final class HybridNitroWebView:
           nativeEvent: NitroWebViewRenderProcessGoneNativeEvent(didCrash: nil)
         )
       )
+    }
+
+    /// WebKit hands us the `WKDownload` produced by the `.download` policy
+    /// above. We own the download's lifecycle and pick a temp-file
+    /// destination in `download(_:decideDestinationUsing:...)`.
+    func webView(
+      _ webView: WKWebView,
+      navigationResponse: WKNavigationResponse,
+      didBecome download: WKDownload
+    ) {
+      download.delegate = self
     }
   }
 
@@ -545,6 +637,23 @@ final class HybridNitroWebView:
   ///   * Keeps the decision out of the `WKNavigationDelegate` callback
   ///     so future contributors can extend it (e.g. honor a future
   ///     `download` attribute hint) in one place.
+  /// Whether a navigation response is a `blob:` download that should be
+  /// routed through `WKDownloadDelegate` (temp-file streaming) rather than
+  /// the HTTP `shouldTreatAsDownload` cancel-and-emit path.
+  ///
+  /// True when the response URL scheme is `blob` AND WebKit cannot render it
+  /// inline (`canShowMIMEType == false`) — an inline-renderable blob (e.g. an
+  /// image the page navigates to) should still display, not download.
+  /// Standalone static helper so host-side XCTest can pin the predicate
+  /// without a live `WKWebView` — same rationale as `shouldTreatAsDownload`.
+  static func isBlobDownload(
+    response: URLResponse,
+    canShowMIMEType: Bool
+  ) -> Bool {
+    guard response.url?.scheme?.lowercased() == "blob" else { return false }
+    return !canShowMIMEType
+  }
+
   static func shouldTreatAsDownload(
     response: HTTPURLResponse?,
     canShowMIMEType: Bool
@@ -820,6 +929,67 @@ final class HybridNitroWebView:
       props[.secure] = "TRUE"
     }
     return HTTPCookie(properties: props)
+  }
+
+  /// Emit `onFileDownload` for a blob written to a local temp file by
+  /// `WKDownloadDelegate`. `url` is the local `file://` URL; the rest of the
+  /// metadata is distilled from the download's response the same way an HTTP
+  /// download is (`fileDownload(from:)`), then the URL is overridden to the
+  /// local file so JS reads/saves the on-disk copy.
+  fileprivate func emitBlobFileDownload(
+    localFileURL: URL,
+    response: URLResponse?
+  ) {
+    let base = response.map(Self.fileDownload(from:))
+    let download = FileDownload(
+      url: localFileURL.absoluteString,
+      mimeType: base?.mimeType ?? response?.mimeType,
+      fileName: base?.fileName ?? localFileURL.lastPathComponent,
+      contentLength: base?.contentLength,
+      userAgent: nil
+    )
+    onFileDownload?(FileDownloadEvent(nativeEvent: download))
+  }
+}
+
+// MARK: - WKDownloadDelegate (blob download → temp file)
+
+/// `WKDownloadDelegate` conformance for the navigation delegate. Only blob
+/// downloads reach here (routed via `.download` in `decidePolicyFor
+/// navigationResponse`). WebKit streams the bytes to the temp file we pick in
+/// `decideDestinationUsing`, then `didFinishDownloading` fires and we emit
+/// `onFileDownload` with the local `file://` URL — no base64 crosses the
+/// bridge (iOS 14.5+).
+extension HybridNitroWebView.NavigationDelegate: WKDownloadDelegate {
+  func download(
+    _ download: WKDownload,
+    decideDestinationUsing response: URLResponse,
+    suggestedFilename: String,
+    completionHandler: @escaping (URL?) -> Void
+  ) {
+    let dest = HybridNitroWebView.NavigationDelegate.blobDownloadDestination(
+      suggestedFilename: suggestedFilename
+    )
+    guard let dest else {
+      completionHandler(nil)
+      return
+    }
+    // Stash response + destination — `downloadDidFinish` receives only the
+    // WKDownload, so the finish handler needs both looked up by identity.
+    pendingDownloads[ObjectIdentifier(download)] = (dest, response)
+    completionHandler(dest)
+  }
+
+  func downloadDidFinish(_ download: WKDownload) {
+    guard let entry = pendingDownloads.removeValue(forKey: ObjectIdentifier(download))
+    else { return }
+    owner?.emitBlobFileDownload(localFileURL: entry.url, response: entry.response)
+  }
+
+  func download(_ download: WKDownload, didFailWithError error: Error, resumeData: Data?) {
+    // Drop the stashed entry; a failed blob read surfaces no event (matches
+    // the injected-reader `catch` swallow on Android).
+    pendingDownloads[ObjectIdentifier(download)] = nil
   }
 }
 

--- a/ios/HybridNitroWebView.swift
+++ b/ios/HybridNitroWebView.swift
@@ -180,9 +180,8 @@ final class HybridNitroWebView:
   func reload() throws { view.reload() }
   func stopLoading() throws { view.stopLoading() }
 
-  /// Clear the cache-shaped record types from the view's data store. The set
-  /// is deliberately cache-only (`Self.cacheDataTypes()`) — using
-  /// `allWebsiteDataTypes()` would also wipe cookies/localStorage.
+  /// Clear the cache-shaped record types (`Self.cacheDataTypes()`) from the
+  /// view's data store.
   func clearCache() throws -> Promise<Void> {
     let promise = Promise<Void>()
     view.configuration.websiteDataStore.removeData(
@@ -457,8 +456,7 @@ final class HybridNitroWebView:
     /// `WKDownload` requires a path that does NOT already exist, so each
     /// download gets its own UUID subdirectory — concurrent / repeated
     /// downloads of the same filename never collide. Returns `nil` when the
-    /// destination directory cannot be created. Standalone static helper so
-    /// host-side XCTest can pin the path shape without a live `WKDownload`.
+    /// destination directory cannot be created. Static, host-testable.
     static func blobDownloadDestination(suggestedFilename: String) -> URL? {
       let dir = FileManager.default.temporaryDirectory
         .appendingPathComponent("nitro-webview-blob", isDirectory: true)
@@ -637,15 +635,10 @@ final class HybridNitroWebView:
   ///   * Keeps the decision out of the `WKNavigationDelegate` callback
   ///     so future contributors can extend it (e.g. honor a future
   ///     `download` attribute hint) in one place.
-  /// Whether a navigation response is a `blob:` download that should be
-  /// routed through `WKDownloadDelegate` (temp-file streaming) rather than
-  /// the HTTP `shouldTreatAsDownload` cancel-and-emit path.
-  ///
-  /// True when the response URL scheme is `blob` AND WebKit cannot render it
-  /// inline (`canShowMIMEType == false`) — an inline-renderable blob (e.g. an
-  /// image the page navigates to) should still display, not download.
-  /// Standalone static helper so host-side XCTest can pin the predicate
-  /// without a live `WKWebView` — same rationale as `shouldTreatAsDownload`.
+  /// Whether a `blob:` navigation response should route through
+  /// `WKDownloadDelegate` rather than render inline. Requires
+  /// `canShowMIMEType == false`: an inline-renderable blob (e.g. an image the
+  /// page navigates to) should still display, not download. Static, host-testable.
   static func isBlobDownload(
     response: URLResponse,
     canShowMIMEType: Bool

--- a/iosTests/Tests/HybridNitroWebViewImperativeMethodsTests/HybridNitroWebViewImperativeMethodsTests.swift
+++ b/iosTests/Tests/HybridNitroWebViewImperativeMethodsTests/HybridNitroWebViewImperativeMethodsTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+
+#if canImport(WebKit)
+  import WebKit
+#endif
+
+/// Tests for the imperative-method + blob-download helpers added to
+/// `ios/HybridNitroWebView.swift`:
+///
+///   1. `HybridNitroWebView.cacheDataTypes()` — the cache-only website-data
+///      record set `clearCache()` passes to `removeData(ofTypes:)`. Must be
+///      exactly `{DiskCache, MemoryCache}` and MUST NOT include cookies /
+///      localStorage (using `allWebsiteDataTypes()` would over-clear).
+///   2. `HybridNitroWebView.isBlobDownload(response:canShowMIMEType:)` — the
+///      predicate routing a `blob:` navigation response through
+///      `WKDownloadDelegate` (temp-file streaming) instead of the HTTP
+///      cancel-and-emit path.
+///   3. `HybridNitroWebView.NavigationDelegate.blobDownloadDestination(
+///      suggestedFilename:)` — the unique, non-existent temp-file path a blob
+///      download is written to.
+///
+/// As with every other iOS unit test in this harness, the production class
+/// cannot be linked (it depends on Nitro-generated bridge symbols resolved
+/// only at CocoaPods install time), so each helper is exercised through a
+/// **byte-for-byte probe mirror**. Any change to the production helpers must
+/// be ported here.
+#if canImport(WebKit)
+
+  // MARK: - Production-logic mirrors
+
+  /// Mirror of `HybridNitroWebView.cacheDataTypes()`.
+  fileprivate enum CacheTypesProbe {
+    static func cacheDataTypes() -> Set<String> {
+      [WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache]
+    }
+  }
+
+  /// Mirror of `HybridNitroWebView.isBlobDownload(response:canShowMIMEType:)`.
+  fileprivate enum BlobDownloadProbe {
+    static func isBlobDownload(
+      response: URLResponse,
+      canShowMIMEType: Bool
+    ) -> Bool {
+      guard response.url?.scheme?.lowercased() == "blob" else { return false }
+      return !canShowMIMEType
+    }
+  }
+
+  /// Mirror of
+  /// `HybridNitroWebView.NavigationDelegate.blobDownloadDestination(
+  /// suggestedFilename:)`.
+  fileprivate enum BlobDestinationProbe {
+    static func blobDownloadDestination(suggestedFilename: String) -> URL? {
+      let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("nitro-webview-blob", isDirectory: true)
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+      do {
+        try FileManager.default.createDirectory(
+          at: dir, withIntermediateDirectories: true
+        )
+      } catch {
+        return nil
+      }
+      let name = suggestedFilename.isEmpty ? "download" : suggestedFilename
+      return dir.appendingPathComponent(name)
+    }
+  }
+
+  final class HybridNitroWebViewImperativeMethodsTests: XCTestCase {
+
+    // MARK: - clearCache record types
+
+    func test_cacheDataTypes_isExactlyDiskAndMemoryCache() {
+      let types = CacheTypesProbe.cacheDataTypes()
+      XCTAssertEqual(
+        types,
+        [WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache],
+        "clearCache must scope removeData to exactly the disk + memory cache types."
+      )
+    }
+
+    func test_cacheDataTypes_excludesCookiesAndLocalStorage() {
+      let types = CacheTypesProbe.cacheDataTypes()
+      XCTAssertFalse(
+        types.contains(WKWebsiteDataTypeCookies),
+        "clearCache MUST NOT remove cookies (that's clearCookies' job)."
+      )
+      XCTAssertFalse(
+        types.contains(WKWebsiteDataTypeLocalStorage),
+        "clearCache MUST NOT remove localStorage."
+      )
+    }
+
+    /// The record types clearCache uses must be a strict subset of the
+    /// full removable-types set — proving they are real WebKit identifiers
+    /// AND that we are deliberately NOT using `allWebsiteDataTypes()` (which
+    /// would wipe cookies/storage too).
+    func test_cacheDataTypes_isProperSubsetOfAllWebsiteDataTypes() {
+      let types = CacheTypesProbe.cacheDataTypes()
+      let all = WKWebsiteDataStore.allWebsiteDataTypes()
+      XCTAssertTrue(
+        types.isSubset(of: all),
+        "cache types must be valid removable WebKit data-type identifiers."
+      )
+      XCTAssertTrue(
+        types.isStrictSubset(of: all),
+        "cache types must be a STRICT subset — clearCache is not clearAllData."
+      )
+    }
+
+    // MARK: - isBlobDownload
+
+    private func makeResponse(urlString: String) -> URLResponse {
+      URLResponse(
+        url: URL(string: urlString)!,
+        mimeType: "application/octet-stream",
+        expectedContentLength: -1,
+        textEncodingName: nil
+      )
+    }
+
+    func test_isBlobDownload_true_forBlobSchemeThatCannotRenderInline() {
+      let r = makeResponse(urlString: "blob:https://app.example/abc-123")
+      XCTAssertTrue(
+        BlobDownloadProbe.isBlobDownload(response: r, canShowMIMEType: false),
+        "a blob: response WebKit cannot render inline is a download."
+      )
+    }
+
+    func test_isBlobDownload_false_forBlobSchemeWebKitCanRenderInline() {
+      // An inline-renderable blob (e.g. a PNG the page navigated to) should
+      // display, not download.
+      let r = makeResponse(urlString: "blob:https://app.example/img")
+      XCTAssertFalse(
+        BlobDownloadProbe.isBlobDownload(response: r, canShowMIMEType: true),
+        "an inline-renderable blob: must NOT be forced to download."
+      )
+    }
+
+    func test_isBlobDownload_false_forHttpScheme() {
+      let r = makeResponse(urlString: "https://example.test/file.zip")
+      XCTAssertFalse(
+        BlobDownloadProbe.isBlobDownload(response: r, canShowMIMEType: false),
+        "http(s) downloads take the shouldTreatAsDownload path, not the blob path."
+      )
+    }
+
+    func test_isBlobDownload_isCaseInsensitiveOnScheme() {
+      let r = makeResponse(urlString: "BLOB:https://app.example/x")
+      XCTAssertTrue(
+        BlobDownloadProbe.isBlobDownload(response: r, canShowMIMEType: false),
+        "scheme comparison must be case-insensitive."
+      )
+    }
+
+    // MARK: - blobDownloadDestination
+
+    func test_blobDownloadDestination_isAFileUrlThatDoesNotYetExist() {
+      guard let dest = BlobDestinationProbe.blobDownloadDestination(
+        suggestedFilename: "report.pdf"
+      ) else {
+        return XCTFail("destination must not be nil for a well-formed name")
+      }
+      XCTAssertTrue(dest.isFileURL, "destination must be a file:// URL")
+      XCTAssertEqual(
+        dest.lastPathComponent,
+        "report.pdf",
+        "destination must end with the suggested filename"
+      )
+      XCTAssertFalse(
+        FileManager.default.fileExists(atPath: dest.path),
+        "WKDownload requires the destination file to NOT already exist"
+      )
+      // The parent dir IS created (WKDownload writes into it).
+      XCTAssertTrue(
+        FileManager.default.fileExists(
+          atPath: dest.deletingLastPathComponent().path
+        ),
+        "the parent temp directory must exist so WKDownload can write into it"
+      )
+    }
+
+    func test_blobDownloadDestination_isUniquePerCall() {
+      let a = BlobDestinationProbe.blobDownloadDestination(suggestedFilename: "f.bin")
+      let b = BlobDestinationProbe.blobDownloadDestination(suggestedFilename: "f.bin")
+      XCTAssertNotNil(a)
+      XCTAssertNotNil(b)
+      XCTAssertNotEqual(
+        a, b,
+        "same-name downloads must land in distinct UUID subdirs (no collision)"
+      )
+    }
+
+    func test_blobDownloadDestination_fallsBackToDownloadForEmptyName() {
+      guard let dest = BlobDestinationProbe.blobDownloadDestination(
+        suggestedFilename: ""
+      ) else {
+        return XCTFail("destination must not be nil for empty name")
+      }
+      XCTAssertEqual(
+        dest.lastPathComponent,
+        "download",
+        "an empty suggested filename must fall back to 'download'"
+      )
+    }
+  }
+
+#endif  // canImport(WebKit)

--- a/nitrogen/generated/android/c++/JHybridNitroWebViewSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridNitroWebViewSpec.cpp
@@ -572,5 +572,50 @@ namespace margelo::nitro::nitrowebview {
       return __promise;
     }();
   }
+  std::shared_ptr<Promise<void>> JHybridNitroWebViewSpec::clearCache() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("clearCache");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
+  std::shared_ptr<Promise<void>> JHybridNitroWebViewSpec::clearHistory() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("clearHistory");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
+  std::shared_ptr<Promise<void>> JHybridNitroWebViewSpec::requestFocus() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("requestFocus");
+    auto __result = method(_javaPart);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
 
 } // namespace margelo::nitro::nitrowebview

--- a/nitrogen/generated/android/c++/JHybridNitroWebViewSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridNitroWebViewSpec.hpp
@@ -117,6 +117,9 @@ namespace margelo::nitro::nitrowebview {
     std::shared_ptr<Promise<std::vector<Cookie>>> getCookies(const std::string& url) override;
     std::shared_ptr<Promise<void>> setCookie(const std::string& url, const Cookie& cookie) override;
     std::shared_ptr<Promise<void>> clearCookies() override;
+    std::shared_ptr<Promise<void>> clearCache() override;
+    std::shared_ptr<Promise<void>> clearHistory() override;
+    std::shared_ptr<Promise<void>> requestFocus() override;
 
   private:
     jni::global_ref<JHybridNitroWebViewSpec::JavaPart> _javaPart;

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrowebview/HybridNitroWebViewSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrowebview/HybridNitroWebViewSpec.kt
@@ -309,6 +309,18 @@ abstract class HybridNitroWebViewSpec: HybridView() {
   @DoNotStrip
   @Keep
   abstract fun clearCookies(): Promise<Unit>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun clearCache(): Promise<Unit>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun clearHistory(): Promise<Unit>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun requestFocus(): Promise<Unit>
 
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {

--- a/nitrogen/generated/ios/c++/HybridNitroWebViewSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridNitroWebViewSpecSwift.hpp
@@ -387,6 +387,30 @@ namespace margelo::nitro::nitrowebview {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline std::shared_ptr<Promise<void>> clearCache() override {
+      auto __result = _swiftPart.clearCache();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::shared_ptr<Promise<void>> clearHistory() override {
+      auto __result = _swiftPart.clearHistory();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::shared_ptr<Promise<void>> requestFocus() override {
+      auto __result = _swiftPart.requestFocus();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
 
   private:
     NitroWebview::HybridNitroWebViewSpec_cxx _swiftPart;

--- a/nitrogen/generated/ios/swift/HybridNitroWebViewSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroWebViewSpec.swift
@@ -49,6 +49,9 @@ public protocol HybridNitroWebViewSpec_protocol: HybridObject, HybridView {
   func getCookies(url: String) throws -> Promise<[Cookie]>
   func setCookie(url: String, cookie: Cookie) throws -> Promise<Void>
   func clearCookies() throws -> Promise<Void>
+  func clearCache() throws -> Promise<Void>
+  func clearHistory() throws -> Promise<Void>
+  func requestFocus() throws -> Promise<Void>
 }
 
 public extension HybridNitroWebViewSpec_protocol {

--- a/nitrogen/generated/ios/swift/HybridNitroWebViewSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroWebViewSpec_cxx.swift
@@ -1039,6 +1039,63 @@ open class HybridNitroWebViewSpec_cxx {
     }
   }
   
+  @inline(__always)
+  public final func clearCache() -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.clearCache()
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func clearHistory() -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.clearHistory()
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func requestFocus() -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.requestFocus()
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
+  
   public final func getView() -> UnsafeMutableRawPointer {
     return Unmanaged.passRetained(__implementation.view).toOpaque()
   }

--- a/nitrogen/generated/shared/c++/HybridNitroWebViewSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridNitroWebViewSpec.cpp
@@ -78,6 +78,9 @@ namespace margelo::nitro::nitrowebview {
       prototype.registerHybridMethod("getCookies", &HybridNitroWebViewSpec::getCookies);
       prototype.registerHybridMethod("setCookie", &HybridNitroWebViewSpec::setCookie);
       prototype.registerHybridMethod("clearCookies", &HybridNitroWebViewSpec::clearCookies);
+      prototype.registerHybridMethod("clearCache", &HybridNitroWebViewSpec::clearCache);
+      prototype.registerHybridMethod("clearHistory", &HybridNitroWebViewSpec::clearHistory);
+      prototype.registerHybridMethod("requestFocus", &HybridNitroWebViewSpec::requestFocus);
     });
   }
 

--- a/nitrogen/generated/shared/c++/HybridNitroWebViewSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitroWebViewSpec.hpp
@@ -152,6 +152,9 @@ namespace margelo::nitro::nitrowebview {
       virtual std::shared_ptr<Promise<std::vector<Cookie>>> getCookies(const std::string& url) = 0;
       virtual std::shared_ptr<Promise<void>> setCookie(const std::string& url, const Cookie& cookie) = 0;
       virtual std::shared_ptr<Promise<void>> clearCookies() = 0;
+      virtual std::shared_ptr<Promise<void>> clearCache() = 0;
+      virtual std::shared_ptr<Promise<void>> clearHistory() = 0;
+      virtual std::shared_ptr<Promise<void>> requestFocus() = 0;
 
     protected:
       // Hybrid Setup

--- a/src/__tests__/blob-reader-envelope.test.ts
+++ b/src/__tests__/blob-reader-envelope.test.ts
@@ -1,0 +1,177 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  BLOB_ENVELOPE_KEY,
+  buildBlobReaderScript,
+  parseBlobEnvelope,
+} from '../bridgeScript.ts'
+
+/**
+ * Round-trip contract for the Android blob-download path.
+ *
+ * `buildBlobReaderScript` produces JS that (in the page) reads a `blob:` URL
+ * to a data URL and posts a reserved envelope through
+ * `window.ReactNativeWebView.postMessage`. `parseBlobEnvelope` is the demux
+ * the native message sink runs to route that envelope to `onFileDownload`
+ * instead of `onMessage`.
+ *
+ * These are pure-TS (run by `node --test --experimental-strip-types`) — the
+ * reader script is evaluated in a `new Function(...)` sandbox with mocked
+ * `fetch` / `FileReader`, exactly like `evaluateBridgeScript`. The Kotlin
+ * ports (`HybridNitroWebView.buildBlobReaderScript` / `parseBlobEnvelope`)
+ * mirror this canonical logic and have their own JVM unit tests.
+ */
+
+function createSpy() {
+  const calls: string[] = []
+  const postMessage = (data: string): void => {
+    calls.push(data)
+  }
+  return { postMessage, calls }
+}
+
+// Minimal in-page mocks: a Blob, a fetch that resolves it, and a FileReader
+// that produces a fixed data URL asynchronously (mirrors the real async
+// readAsDataURL settle).
+function makeSandbox(
+  spy: ReturnType<typeof createSpy>,
+  blob: { type: string; size: number },
+  dataUrl: string
+) {
+  const win = {
+    ReactNativeWebView: { postMessage: spy.postMessage },
+  }
+  const fetchMock = (_u: string) =>
+    Promise.resolve({ blob: () => Promise.resolve(blob) })
+  class FileReaderMock {
+    result = ''
+    onloadend: (() => void) | null = null
+    readAsDataURL(_b: unknown): void {
+      this.result = dataUrl
+      queueMicrotask(() => this.onloadend?.())
+    }
+  }
+  return { win, fetchMock, FileReaderMock }
+}
+
+async function runReader(
+  blobUrl: string,
+  suggestedName: string,
+  blob: { type: string; size: number },
+  dataUrl: string
+): Promise<string[]> {
+  const spy = createSpy()
+  const { win, fetchMock, FileReaderMock } = makeSandbox(spy, blob, dataUrl)
+  const src = buildBlobReaderScript(blobUrl, suggestedName)
+  // eslint-disable-next-line no-new-func
+  const evaluate = new Function('window', 'fetch', 'FileReader', src) as (
+    window: unknown,
+    fetch: unknown,
+    FileReader: unknown
+  ) => void
+  evaluate(win, fetchMock, FileReaderMock)
+  // Let the fetch.then + blob.then + readAsDataURL microtasks flush.
+  await new Promise((r) => setTimeout(r, 0))
+  return spy.calls
+}
+
+test('blob reader posts a reserved envelope that parseBlobEnvelope round-trips', async () => {
+  const calls = await runReader(
+    'blob:https://x/abc',
+    'report.pdf',
+    { type: 'application/pdf', size: 5 },
+    'data:application/pdf;base64,JVBERg=='
+  )
+
+  assert.equal(calls.length, 1, 'reader must post exactly one envelope')
+  const parsed = parseBlobEnvelope(calls[0])
+  assert.ok(parsed, 'the posted envelope must parse as a blob payload')
+  assert.equal(parsed!.url, 'blob:https://x/abc')
+  assert.equal(parsed!.dataUrl, 'data:application/pdf;base64,JVBERg==')
+  assert.equal(parsed!.mimeType, 'application/pdf')
+  assert.equal(parsed!.fileName, 'report.pdf')
+  assert.equal(parsed!.size, 5)
+})
+
+test('envelope literally begins with the reserved key prefix', async () => {
+  const calls = await runReader(
+    'blob:https://x/abc',
+    'f.bin',
+    { type: '', size: 0 },
+    'data:application/octet-stream;base64,AA=='
+  )
+  assert.equal(calls.length, 1)
+  assert.ok(
+    calls[0].startsWith(`{"${BLOB_ENVELOPE_KEY}"`),
+    'the envelope must start with the reserved prefix so the native peek matches'
+  )
+})
+
+test('reader tolerates an empty suggested name and a typeless/zero-size blob', async () => {
+  const calls = await runReader(
+    'blob:https://x/empty',
+    '',
+    { type: '', size: 0 },
+    'data:;base64,'
+  )
+  assert.equal(calls.length, 1)
+  const parsed = parseBlobEnvelope(calls[0])
+  assert.ok(parsed)
+  assert.equal(parsed!.mimeType, '')
+  assert.equal(parsed!.fileName, '')
+  assert.equal(parsed!.size, 0)
+})
+
+test('a URL with quotes/backslashes cannot break out of the source literal', async () => {
+  // If the blob URL were not JSON-encoded, these characters would terminate
+  // the string literal and corrupt the injected script.
+  const nasty = 'blob:https://x/a"b\\c'
+  const calls = await runReader(
+    nasty,
+    'n"a\\me.bin',
+    { type: 'text/plain', size: 3 },
+    'data:text/plain;base64,YWJj'
+  )
+  assert.equal(calls.length, 1)
+  const parsed = parseBlobEnvelope(calls[0])
+  assert.ok(parsed)
+  assert.equal(parsed!.url, nasty, 'the exact URL must survive the round-trip')
+  assert.equal(parsed!.fileName, 'n"a\\me.bin')
+})
+
+test('parseBlobEnvelope returns null for normal onMessage payloads (channel isolation)', () => {
+  // Anything that is NOT our reserved envelope must fall through to onMessage.
+  assert.equal(parseBlobEnvelope('hello'), null)
+  assert.equal(parseBlobEnvelope(''), null)
+  assert.equal(parseBlobEnvelope('{"k":"v"}'), null, 'not our key → null')
+  assert.equal(
+    parseBlobEnvelope('{"user":"__nitro_blob__"}'),
+    null,
+    'the key appearing as a VALUE elsewhere must not be treated as an envelope'
+  )
+  assert.equal(
+    parseBlobEnvelope(`{"${BLOB_ENVELOPE_KEY}":{}}`),
+    null,
+    'missing url/dataUrl → null (malformed envelope is not a download)'
+  )
+  assert.equal(
+    parseBlobEnvelope(`{"${BLOB_ENVELOPE_KEY}"broken`),
+    null,
+    'a matching prefix but invalid JSON → null (never throws)'
+  )
+})
+
+test('parseBlobEnvelope defaults optional fields when absent', () => {
+  const raw = JSON.stringify({
+    [BLOB_ENVELOPE_KEY]: {
+      url: 'blob:https://x/1',
+      dataUrl: 'data:;base64,',
+    },
+  })
+  const parsed = parseBlobEnvelope(raw)
+  assert.ok(parsed)
+  assert.equal(parsed!.mimeType, '')
+  assert.equal(parsed!.fileName, '')
+  assert.equal(parsed!.size, 0)
+})

--- a/src/__tests__/blob-reader-envelope.test.ts
+++ b/src/__tests__/blob-reader-envelope.test.ts
@@ -1,143 +1,32 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import {
-  BLOB_ENVELOPE_KEY,
-  buildBlobReaderScript,
-  parseBlobEnvelope,
-} from '../bridgeScript.ts'
+import { BLOB_ENVELOPE_KEY, parseBlobEnvelope } from '../bridgeScript.ts'
 
 /**
- * Round-trip contract for the Android blob-download path.
- *
- * `buildBlobReaderScript` produces JS that (in the page) reads a `blob:` URL
- * to a data URL and posts a reserved envelope through
- * `window.ReactNativeWebView.postMessage`. `parseBlobEnvelope` is the demux
- * the native message sink runs to route that envelope to `onFileDownload`
- * instead of `onMessage`.
- *
- * These are pure-TS (run by `node --test --experimental-strip-types`) — the
- * reader script is evaluated in a `new Function(...)` sandbox with mocked
- * `fetch` / `FileReader`, exactly like `evaluateBridgeScript`. The Kotlin
- * ports (`HybridNitroWebView.buildBlobReaderScript` / `parseBlobEnvelope`)
- * mirror this canonical logic and have their own JVM unit tests.
+ * `parseBlobEnvelope` is the spec-of-record demux the native message sink runs
+ * to route a reserved blob envelope to `onFileDownload` instead of `onMessage`.
+ * The Kotlin port (`HybridNitroWebView.parseBlobEnvelope`) mirrors this and has
+ * its own JVM unit tests.
  */
 
-function createSpy() {
-  const calls: string[] = []
-  const postMessage = (data: string): void => {
-    calls.push(data)
-  }
-  return { postMessage, calls }
-}
-
-// Minimal in-page mocks: a Blob, a fetch that resolves it, and a FileReader
-// that produces a fixed data URL asynchronously (mirrors the real async
-// readAsDataURL settle).
-function makeSandbox(
-  spy: ReturnType<typeof createSpy>,
-  blob: { type: string; size: number },
-  dataUrl: string
-) {
-  const win = {
-    ReactNativeWebView: { postMessage: spy.postMessage },
-  }
-  const fetchMock = (_u: string) =>
-    Promise.resolve({ blob: () => Promise.resolve(blob) })
-  class FileReaderMock {
-    result = ''
-    onloadend: (() => void) | null = null
-    readAsDataURL(_b: unknown): void {
-      this.result = dataUrl
-      queueMicrotask(() => this.onloadend?.())
-    }
-  }
-  return { win, fetchMock, FileReaderMock }
-}
-
-async function runReader(
-  blobUrl: string,
-  suggestedName: string,
-  blob: { type: string; size: number },
-  dataUrl: string
-): Promise<string[]> {
-  const spy = createSpy()
-  const { win, fetchMock, FileReaderMock } = makeSandbox(spy, blob, dataUrl)
-  const src = buildBlobReaderScript(blobUrl, suggestedName)
-  // eslint-disable-next-line no-new-func
-  const evaluate = new Function('window', 'fetch', 'FileReader', src) as (
-    window: unknown,
-    fetch: unknown,
-    FileReader: unknown
-  ) => void
-  evaluate(win, fetchMock, FileReaderMock)
-  // Let the fetch.then + blob.then + readAsDataURL microtasks flush.
-  await new Promise((r) => setTimeout(r, 0))
-  return spy.calls
-}
-
-test('blob reader posts a reserved envelope that parseBlobEnvelope round-trips', async () => {
-  const calls = await runReader(
-    'blob:https://x/abc',
-    'report.pdf',
-    { type: 'application/pdf', size: 5 },
-    'data:application/pdf;base64,JVBERg=='
-  )
-
-  assert.equal(calls.length, 1, 'reader must post exactly one envelope')
-  const parsed = parseBlobEnvelope(calls[0])
-  assert.ok(parsed, 'the posted envelope must parse as a blob payload')
+test('parseBlobEnvelope demuxes a well-formed envelope', () => {
+  const raw = JSON.stringify({
+    [BLOB_ENVELOPE_KEY]: {
+      url: 'blob:https://x/abc',
+      dataUrl: 'data:application/pdf;base64,JVBERg==',
+      mimeType: 'application/pdf',
+      fileName: 'report.pdf',
+      size: 5,
+    },
+  })
+  const parsed = parseBlobEnvelope(raw)
+  assert.ok(parsed)
   assert.equal(parsed!.url, 'blob:https://x/abc')
   assert.equal(parsed!.dataUrl, 'data:application/pdf;base64,JVBERg==')
   assert.equal(parsed!.mimeType, 'application/pdf')
   assert.equal(parsed!.fileName, 'report.pdf')
   assert.equal(parsed!.size, 5)
-})
-
-test('envelope literally begins with the reserved key prefix', async () => {
-  const calls = await runReader(
-    'blob:https://x/abc',
-    'f.bin',
-    { type: '', size: 0 },
-    'data:application/octet-stream;base64,AA=='
-  )
-  assert.equal(calls.length, 1)
-  assert.ok(
-    calls[0].startsWith(`{"${BLOB_ENVELOPE_KEY}"`),
-    'the envelope must start with the reserved prefix so the native peek matches'
-  )
-})
-
-test('reader tolerates an empty suggested name and a typeless/zero-size blob', async () => {
-  const calls = await runReader(
-    'blob:https://x/empty',
-    '',
-    { type: '', size: 0 },
-    'data:;base64,'
-  )
-  assert.equal(calls.length, 1)
-  const parsed = parseBlobEnvelope(calls[0])
-  assert.ok(parsed)
-  assert.equal(parsed!.mimeType, '')
-  assert.equal(parsed!.fileName, '')
-  assert.equal(parsed!.size, 0)
-})
-
-test('a URL with quotes/backslashes cannot break out of the source literal', async () => {
-  // If the blob URL were not JSON-encoded, these characters would terminate
-  // the string literal and corrupt the injected script.
-  const nasty = 'blob:https://x/a"b\\c'
-  const calls = await runReader(
-    nasty,
-    'n"a\\me.bin',
-    { type: 'text/plain', size: 3 },
-    'data:text/plain;base64,YWJj'
-  )
-  assert.equal(calls.length, 1)
-  const parsed = parseBlobEnvelope(calls[0])
-  assert.ok(parsed)
-  assert.equal(parsed!.url, nasty, 'the exact URL must survive the round-trip')
-  assert.equal(parsed!.fileName, 'n"a\\me.bin')
 })
 
 test('parseBlobEnvelope returns null for normal onMessage payloads (channel isolation)', () => {

--- a/src/__tests__/imperative-methods-signature.test.ts
+++ b/src/__tests__/imperative-methods-signature.test.ts
@@ -1,0 +1,77 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import type { NitroWebViewMethods } from '../specs/NitroWebView.nitro.ts'
+
+/**
+ * Signature pins for the three imperative methods added to
+ * `NitroWebViewMethods`: `clearCache()`, `clearHistory()`, `requestFocus()`.
+ *
+ * All three are `() => Promise<void>` — uniform with the existing async
+ * methods (`clearCookies`) so callers have one mental model. If the spec ever
+ * drifts (e.g. someone makes `requestFocus` synchronous `void`), the
+ * type-level pins below fail `yarn typecheck` before tests even run.
+ *
+ * JS-only (run by `node --test --experimental-strip-types`); the native iOS /
+ * Android implementations are exercised by their own XCTest / JUnit suites.
+ */
+
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false
+
+type Assert<T extends true> = T
+
+type _ClearCache_Sig = Assert<
+  Equals<NitroWebViewMethods['clearCache'], () => Promise<void>>
+>
+type _ClearHistory_Sig = Assert<
+  Equals<NitroWebViewMethods['clearHistory'], () => Promise<void>>
+>
+type _RequestFocus_Sig = Assert<
+  Equals<NitroWebViewMethods['requestFocus'], () => Promise<void>>
+>
+
+// Touch the aliases so the compiler does not tree-shake them away.
+const _pins: [_ClearCache_Sig, _ClearHistory_Sig, _RequestFocus_Sig] = [
+  true,
+  true,
+  true,
+]
+if (_pins.some((p) => p !== true)) throw new Error('unreachable')
+
+// A narrow fake satisfying just the three methods (plus typed stubs the
+// interface requires) so the runtime shape can be exercised.
+class FakeMethods implements Pick<
+  NitroWebViewMethods,
+  'clearCache' | 'clearHistory' | 'requestFocus'
+> {
+  clearCache(): Promise<void> {
+    return Promise.resolve()
+  }
+  clearHistory(): Promise<void> {
+    return Promise.resolve()
+  }
+  requestFocus(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+const METHODS = ['clearCache', 'clearHistory', 'requestFocus'] as const
+
+for (const name of METHODS) {
+  test(`${name} is a zero-arg function returning a Promise<void>`, async () => {
+    const fake = new FakeMethods()
+    const fn = fake[name].bind(fake) as () => Promise<void>
+    assert.equal(typeof fn, 'function', `${name} must be a function`)
+    assert.equal(
+      fn.length,
+      0,
+      `${name} must declare zero positional parameters`
+    )
+    const ret = fn()
+    assert.ok(ret instanceof Promise, `${name} must return a Promise`)
+    assert.equal(await ret, undefined, `${name} must resolve to undefined`)
+  })
+}

--- a/src/bridgeScript.ts
+++ b/src/bridgeScript.ts
@@ -109,6 +109,115 @@ export function buildPostMessageScript(
 }
 
 /**
+ * Reserved discriminator key for blob-download payloads posted back through
+ * the existing `ReactNativeWebView.postMessage` bridge. A native message sink
+ * peeks for this key before treating a payload as a normal `onMessage` string
+ * — see {@linkcode parseBlobEnvelope}. Chosen to be collision-proof with a
+ * real string payload (the `{"__nitro_blob__"` prefix).
+ */
+export const BLOB_ENVELOPE_KEY: '__nitro_blob__' = '__nitro_blob__'
+
+/** Fields carried inside a {@linkcode BlobDownloadEnvelope}. */
+export interface BlobDownloadPayload {
+  /** The original `blob:` URL the download was requested for. */
+  url: string
+  /** `"data:<mime>;base64,<...>"` — the blob read to a data URL. */
+  dataUrl: string
+  /** MIME type from `Blob.type` (may be empty). */
+  mimeType: string
+  /** Best-effort suggested file name (native-derived; usually junk). */
+  fileName: string
+  /** Byte length from `Blob.size` (0 when unknown). */
+  size: number
+}
+
+/** Reserved envelope shape wrapping a {@linkcode BlobDownloadPayload}. */
+export interface BlobDownloadEnvelope {
+  [BLOB_ENVELOPE_KEY]: BlobDownloadPayload
+}
+
+/**
+ * Build the JS source injected into the page to resolve a `blob:` URL that
+ * the native download hook cannot fetch (blobs live only in the web context).
+ *
+ * Reads the blob in-page via `fetch(blobUrl) → .blob() → FileReader
+ * .readAsDataURL` and posts a reserved {@linkcode BlobDownloadEnvelope}
+ * through the EXISTING `ReactNativeWebView.postMessage` bridge. The native
+ * side demuxes it (see {@linkcode parseBlobEnvelope}) and emits
+ * `onFileDownload`. No new bridge name is introduced.
+ *
+ * `suggestedName` is native-derived (Android: `guessFileName` off the blob
+ * URL — usually junk). The page's real download name is not recoverable from
+ * a bare `blob:` URL, so callers treat `fileName` as best-effort.
+ *
+ * This path is Android-only: iOS uses `WKDownloadDelegate` to stream the blob
+ * to a temp file natively (no base64-over-bridge).
+ */
+export function buildBlobReaderScript(
+  blobUrl: string,
+  suggestedName: string
+): string {
+  // JSON-encode inputs so quotes/backslashes in the URL can't break out of
+  // the source-string literal.
+  const urlLit = JSON.stringify(blobUrl)
+  const nameLit = JSON.stringify(suggestedName)
+  const keyLit = JSON.stringify(BLOB_ENVELOPE_KEY)
+  // IIFE-wrapped; every failure path swallows so the page never throws.
+  return `;(function () {
+  try {
+    fetch(${urlLit}).then(function (r) { return r.blob(); }).then(function (b) {
+      var reader = new FileReader();
+      reader.onloadend = function () {
+        var dataUrl = String(reader.result || '');
+        var envelope = {};
+        envelope[${keyLit}] = {
+          url: ${urlLit},
+          dataUrl: dataUrl,
+          mimeType: b.type || '',
+          fileName: ${nameLit},
+          size: b.size || 0
+        };
+        var br = window.${BRIDGE_NAME};
+        if (br && typeof br.postMessage === 'function') {
+          br.postMessage(JSON.stringify(envelope));
+        }
+      };
+      reader.readAsDataURL(b);
+    })["catch"](function () { /* blob gone / cross-origin: swallow */ });
+  } catch (e) { /* no fetch/FileReader: swallow, no page throw */ }
+})();`
+}
+
+/**
+ * Parse a raw `postMessage` string and return the blob payload, or `null`
+ * when the string is a normal `onMessage` payload. A cheap prefix peek runs
+ * before the `JSON.parse` cost so ordinary payloads are forwarded untouched.
+ * This is the single canonical demux, ported verbatim into each native sink.
+ */
+export function parseBlobEnvelope(raw: string): BlobDownloadPayload | null {
+  if (typeof raw !== 'string') return null
+  // Prefix peek: only a payload literally starting with the reserved key can
+  // be ours. A user string that merely contains the key elsewhere is not.
+  if (raw.indexOf(`{"${BLOB_ENVELOPE_KEY}"`) !== 0) return null
+  try {
+    const obj = JSON.parse(raw) as Partial<BlobDownloadEnvelope>
+    const b = obj?.[BLOB_ENVELOPE_KEY]
+    if (!b || typeof b.url !== 'string' || typeof b.dataUrl !== 'string') {
+      return null
+    }
+    return {
+      url: b.url,
+      dataUrl: b.dataUrl,
+      mimeType: typeof b.mimeType === 'string' ? b.mimeType : '',
+      fileName: typeof b.fileName === 'string' ? b.fileName : '',
+      size: typeof b.size === 'number' ? b.size : 0,
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
  * Sandbox shape for evaluating the iOS bridge script.
  */
 export interface IosBridgeSandbox {

--- a/src/bridgeScript.ts
+++ b/src/bridgeScript.ts
@@ -27,10 +27,10 @@ export interface AndroidNativeBridge {
  * Build the literal JavaScript source string for the injected bridge.
  *
  * The script:
- *   - Defines `window.ReactNativeWebView` (idempotent — preserves any
+ *   - Defines `window.ReactNativeWebView` (idempotent; preserves any
  *     pre-existing object the page author installed).
  *   - Defines `window.ReactNativeWebView.postMessage(data)` (also
- *     idempotent — never overwrites an existing function).
+ *     idempotent; never overwrites an existing function).
  *   - String-coerces `data` before routing.
  *   - Routes to the platform-native handler (WebKit messageHandler on iOS,
  *     `ReactNativeWebViewNative` on Android).
@@ -117,11 +117,11 @@ export function buildPostMessageScript(
  */
 export const BLOB_ENVELOPE_KEY: '__nitro_blob__' = '__nitro_blob__'
 
-/** Fields carried inside a {@linkcode BlobDownloadEnvelope}. */
+/** Blob-download payload demuxed out of a reserved envelope. */
 export interface BlobDownloadPayload {
   /** The original `blob:` URL the download was requested for. */
   url: string
-  /** `"data:<mime>;base64,<...>"` — the blob read to a data URL. */
+  /** `"data:<mime>;base64,<...>"`: the blob read to a data URL. */
   dataUrl: string
   /** MIME type from `Blob.type` (may be empty). */
   mimeType: string
@@ -131,68 +131,11 @@ export interface BlobDownloadPayload {
   size: number
 }
 
-/** Reserved envelope shape wrapping a {@linkcode BlobDownloadPayload}. */
-export interface BlobDownloadEnvelope {
-  [BLOB_ENVELOPE_KEY]: BlobDownloadPayload
-}
-
 /**
- * Build the JS source injected into the page to resolve a `blob:` URL that
- * the native download hook cannot fetch (blobs live only in the web context).
- *
- * Reads the blob in-page via `fetch(blobUrl) → .blob() → FileReader
- * .readAsDataURL` and posts a reserved {@linkcode BlobDownloadEnvelope}
- * through the EXISTING `ReactNativeWebView.postMessage` bridge. The native
- * side demuxes it (see {@linkcode parseBlobEnvelope}) and emits
- * `onFileDownload`. No new bridge name is introduced.
- *
- * `suggestedName` is native-derived (Android: `guessFileName` off the blob
- * URL — usually junk). The page's real download name is not recoverable from
- * a bare `blob:` URL, so callers treat `fileName` as best-effort.
- *
- * This path is Android-only: iOS uses `WKDownloadDelegate` to stream the blob
- * to a temp file natively (no base64-over-bridge).
- */
-export function buildBlobReaderScript(
-  blobUrl: string,
-  suggestedName: string
-): string {
-  // JSON-encode inputs so quotes/backslashes in the URL can't break out of
-  // the source-string literal.
-  const urlLit = JSON.stringify(blobUrl)
-  const nameLit = JSON.stringify(suggestedName)
-  const keyLit = JSON.stringify(BLOB_ENVELOPE_KEY)
-  // IIFE-wrapped; every failure path swallows so the page never throws.
-  return `;(function () {
-  try {
-    fetch(${urlLit}).then(function (r) { return r.blob(); }).then(function (b) {
-      var reader = new FileReader();
-      reader.onloadend = function () {
-        var dataUrl = String(reader.result || '');
-        var envelope = {};
-        envelope[${keyLit}] = {
-          url: ${urlLit},
-          dataUrl: dataUrl,
-          mimeType: b.type || '',
-          fileName: ${nameLit},
-          size: b.size || 0
-        };
-        var br = window.${BRIDGE_NAME};
-        if (br && typeof br.postMessage === 'function') {
-          br.postMessage(JSON.stringify(envelope));
-        }
-      };
-      reader.readAsDataURL(b);
-    })["catch"](function () { /* blob gone / cross-origin: swallow */ });
-  } catch (e) { /* no fetch/FileReader: swallow, no page throw */ }
-})();`
-}
-
-/**
- * Parse a raw `postMessage` string and return the blob payload, or `null`
- * when the string is a normal `onMessage` payload. A cheap prefix peek runs
- * before the `JSON.parse` cost so ordinary payloads are forwarded untouched.
- * This is the single canonical demux, ported verbatim into each native sink.
+ * Spec-of-record demux for the blob-download bridge, kept as the reference the
+ * native Kotlin port (`HybridNitroWebView.parseBlobEnvelope`) must match. Parses
+ * a raw `postMessage` string to a blob payload, or `null` for a normal
+ * `onMessage` payload; a cheap prefix peek runs before the `JSON.parse` cost.
  */
 export function parseBlobEnvelope(raw: string): BlobDownloadPayload | null {
   if (typeof raw !== 'string') return null
@@ -200,7 +143,9 @@ export function parseBlobEnvelope(raw: string): BlobDownloadPayload | null {
   // be ours. A user string that merely contains the key elsewhere is not.
   if (raw.indexOf(`{"${BLOB_ENVELOPE_KEY}"`) !== 0) return null
   try {
-    const obj = JSON.parse(raw) as Partial<BlobDownloadEnvelope>
+    const obj = JSON.parse(raw) as {
+      [BLOB_ENVELOPE_KEY]?: Partial<BlobDownloadPayload>
+    }
     const b = obj?.[BLOB_ENVELOPE_KEY]
     if (!b || typeof b.url !== 'string' || typeof b.dataUrl !== 'string') {
       return null

--- a/src/specs/NitroWebView.nitro.ts
+++ b/src/specs/NitroWebView.nitro.ts
@@ -410,9 +410,15 @@ export interface NitroWebViewProps extends HybridViewProps {
    *     `WebView.setDownloadListener` — every `onDownloadStart` invocation
    *     translates directly into a single `onFileDownload` emission.
    *
-   * The WebView itself never persists the file to disk: JS is solely
-   * responsible for handling the download metadata. Blob URLs (`blob:`)
-   * are explicitly out of scope for this MVP and do not surface an event.
+   * The WebView itself never persists a normal (http/https) download to
+   * disk: JS is solely responsible for handling the download metadata.
+   *
+   * Blob downloads (`blob:`) DO surface an `onFileDownload` event, resolved
+   * to a local reference in `nativeEvent.url` (iOS: a `file://` URL written
+   * natively via `WKDownloadDelegate`; Android: a `data:` URL read in-page
+   * and bridged back). See {@linkcode FileDownload.url} for the platform
+   * distinction. No extra prop is required — a consumer already listening to
+   * `onFileDownload` receives blob downloads for free.
    */
   onFileDownload?: (event: FileDownloadEvent) => void
 
@@ -627,6 +633,55 @@ export interface NitroWebViewMethods extends HybridViewMethods {
    * The promise resolves only after the platform reports completion.
    */
   clearCookies(): Promise<void>
+
+  /**
+   * Clear the WebView's resource cache (in-memory + on-disk fetched
+   * responses). Does NOT clear cookies (use {@linkcode clearCookies}),
+   * localStorage, or the back/forward history.
+   *
+   *   - iOS (WKWebView): removes only the cache-shaped record types from the
+   *     view's `configuration.websiteDataStore` —
+   *     `WKWebsiteDataTypeDiskCache` and `WKWebsiteDataTypeMemoryCache` — via
+   *     `removeData(ofTypes:modifiedSince:)` with `modifiedSince:
+   *     .distantPast`. Cookies and localStorage are left intact because their
+   *     record types are excluded from the set (do NOT use
+   *     `allWebsiteDataTypes()`, which would also wipe them).
+   *   - Android (android.webkit.WebView): `WebView.clearCache(true)` on the
+   *     UI thread (`true` also purges the on-disk cache files, not just the
+   *     RAM cache).
+   *
+   * Resolves once the platform reports the removal is complete.
+   */
+  clearCache(): Promise<void>
+
+  /**
+   * Clear the WebView's back/forward navigation list.
+   *
+   *   - Android (android.webkit.WebView): `WebView.clearHistory()` on the UI
+   *     thread. Clears the list except the current page.
+   *   - iOS (WKWebView): **NO-OP.** WKWebView exposes no public API to mutate
+   *     `backForwardList` (it is read-only with no clear/prune method). This
+   *     method resolves WITHOUT clearing on iOS rather than reloading
+   *     `about:blank` — a reload would change the current URL and drop
+   *     forward entries as a side effect, which is surprising for a "clear
+   *     history" call. Callers needing a pristine stack on iOS should
+   *     navigate to a fresh `source` instead. Mirrors react-native-webview,
+   *     which exposes `clearHistory` on Android only.
+   */
+  clearHistory(): Promise<void>
+
+  /**
+   * Move keyboard/input focus to the WebView so the next key event (or a
+   * focused form field inside the page) receives input without a user tap.
+   *
+   *   - iOS (WKWebView): `becomeFirstResponder()` on the main thread. The
+   *     Promise resolves regardless of the responder's own return value (a
+   *     `false` return just means the view was already first responder or the
+   *     window is not key — not an error).
+   *   - Android (android.webkit.WebView): `WebView.requestFocus()` on the UI
+   *     thread.
+   */
+  requestFocus(): Promise<void>
 }
 
 export type NitroWebView = HybridView<NitroWebViewProps, NitroWebViewMethods>
@@ -665,8 +720,17 @@ export interface Cookie {
  * platform — JS decides what to do with the URL.
  *
  * Field semantics:
- *   - `url`           — Absolute download URL. Required. Always a remote
- *                       URL (http/https). Blob URLs are out of scope.
+ *   - `url`           — Absolute download URL. Required. For a normal
+ *                       download this is the remote URL (http/https). For a
+ *                       `blob:` download the field carries a resolved local
+ *                       reference instead, and the shape differs by platform:
+ *                       iOS delivers a local `file://` URL (the blob is
+ *                       streamed to a temp file natively via
+ *                       `WKDownloadDelegate`), while Android delivers a
+ *                       `data:` URL (the blob is read in-page to a data URL
+ *                       and bridged back). Either form can be `fetch()`-ed /
+ *                       saved by the consumer; the original `blob:` URL is
+ *                       not surfaced because it is dead once the page unloads.
  *   - `mimeType`      — MIME type reported by the platform. Optional;
  *                       absent when neither the navigation response nor the
  *                       Android `DownloadListener` provided one.


### PR DESCRIPTION
## Summary

Adds three imperative methods and blob URL (`blob:`) download support to the
`react-native-webview` drop-in. Cookie/blob symmetry is closed on the read
paths; Android cookie full-attribute read stays a documented won't-fix (no
public Android API beyond `CookieManager.getCookie()`'s name=value header).

**Imperative methods** (`NitroWebViewMethods`, all uniform `Promise<void>`):

- `clearCache()` — iOS scopes `removeData` to `{DiskCache, MemoryCache}` only
  (NOT `allWebsiteDataTypes()`, which would also wipe cookies/localStorage);
  Android `clearCache(true)`.
- `clearHistory()` — Android `WebView.clearHistory()`. **iOS is a documented
  no-op**: `WKWebView.backForwardList` is read-only with no public prune API.
  It resolves without clearing rather than doing an `about:blank` reload
  workaround (a reload changes the current URL and drops forward entries — not
  a real "clear"). Matches react-native-webview, which is Android-only here.
- `requestFocus()` — iOS `becomeFirstResponder()` on main; Android
  `requestFocus()`.

**Blob download — deliberately platform-asymmetric** (the interesting part):

- **iOS: native `WKDownloadDelegate`** (iOS 14.5+, below any RN floor — no
  fallback tier). The existing `decidePolicyFor navigationResponse` hook now
  returns `.download` for a blob response WebKit can't render inline;
  `navigationResponse:didBecome:` hands off a `WKDownload`, which streams the
  bytes to a per-download UUID temp file. `onFileDownload` then fires with a
  local `file://` URL. **No bytes cross the JS bridge.**
- **Android: base64 bridge** (no `WKDownloadDelegate` equivalent). The `blob:`
  short-circuit in `onDownloadStart` is replaced by injecting a reader
  (`fetch → FileReader.readAsDataURL`) that posts a reserved envelope
  (`{"__nitro_blob__":{...}}`) through the existing message bridge. The
  message sink peeks for that reserved key BEFORE treating the payload as a
  normal `onMessage`, and emits `onFileDownload` with the `data:` URL. This is
  the one place a `data:` URL is legitimate in `FileDownload.url`.

This asymmetry is intentional: iOS gets a genuinely better path (temp file, no
O(fileSize) memory ceiling); Android's base64 route carries a `ponytail:`
comment naming the memory ceiling and the temp-file-streaming upgrade path.
Either way a consumer already listening to `onFileDownload` gets blob
downloads for free — no new prop.

The `FileDownload.url` JSDoc (previously "Always a remote URL. Blob URLs are
out of scope" — now false) and the `onFileDownload` JSDoc were corrected to
spell out the three-way `url` distinction (remote / `file://` / `data:`).

The blob reader script and envelope parser live as pure TS in
`bridgeScript.ts` (`buildBlobReaderScript` / `parseBlobEnvelope`); the native
sides carry behavior-identical ports.

## Test plan

- **TS** (`yarn test`, 264 pass; `yarn typecheck` clean; `yarn lint-ci`
  clean):
  - `blob-reader-envelope.test.ts` — evaluates the reader script in a
    `vm`-style `new Function` sandbox with mocked `fetch`/`FileReader`,
    asserts the reserved envelope round-trips through `parseBlobEnvelope`
    (incl. quote/backslash injection safety), and pins channel isolation
    (normal `onMessage` strings, the key-as-a-value case, and malformed
    envelopes all return `null`).
  - `imperative-methods-signature.test.ts` — type-pins the three methods to
    `() => Promise<void>`.
- **iOS native** (`./iosTests/run-tests.sh`, 125 pass): new
  `HybridNitroWebViewImperativeMethodsTests` covers `cacheDataTypes()` (exactly
  `{disk, memory}`, excludes cookies/localStorage, strict subset of
  `allWebsiteDataTypes()`), `isBlobDownload(response:canShowMIMEType:)`, and
  `blobDownloadDestination(suggestedFilename:)` (file URL, non-existent,
  unique per call, empty-name fallback).
- **Android**: `HybridNitroWebViewBlobEnvelopeTest` (Robolectric, for real
  `org.json`) covers the `parseBlobEnvelope` / `buildBlobReaderScript` ports.
  The example app's Gradle isn't installed in this environment, so the JVM
  suite wasn't run here; the pure helpers were compiled with `kotlinc` against
  the real `org.json` jar and all round-trip/isolation/injection-safety
  assertions passed.

The WKDownloadDelegate method signatures were verified against current WebKit
(`decidePolicyFor navigationResponse` returning `.download`,
`webView(_:navigationResponse:didBecome:)`, and `downloadDidFinish(_:)` — note
finish takes only the `WKDownload`, so destination + response are stashed by
download identity).